### PR TITLE
[FEAT] 애플 로그인 구현 + 서버 연결

### DIFF
--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		921694FD2BF2207A006DC44A /* APIProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIProvider.swift; sourceTree = "<group>"; };
 		921695002BF220A6006DC44A /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		921695032BF22DCD006DC44A /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
+		921695052BF26E73006DC44A /* roome.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = roome.entitlements; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -158,6 +159,7 @@
 		92DBDA012BCFCF5900E299E2 /* roome */ = {
 			isa = PBXGroup;
 			children = (
+				921695052BF26E73006DC44A /* roome.entitlements */,
 				921694EA2BF1BA7C006DC44A /* Application */,
 				921694EF2BF1BDD7006DC44A /* Data */,
 				921694ED2BF1BB8B006DC44A /* Presentation */,
@@ -390,6 +392,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = roome/roome.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = BMG3X5CM6G;
@@ -417,6 +420,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = roome/roome.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = BMG3X5CM6G;

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		921695012BF220A6006DC44A /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695002BF220A6006DC44A /* NetworkError.swift */; };
 		921695042BF22DCD006DC44A /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695032BF22DCD006DC44A /* UIImage+.swift */; };
 		921695072BF26F23006DC44A /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695062BF26F23006DC44A /* APIConstants.swift */; };
+		921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695082BF302D2006DC44A /* LoginViewModel.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -30,6 +31,7 @@
 		921695032BF22DCD006DC44A /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		921695052BF26E73006DC44A /* roome.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = roome.entitlements; sourceTree = "<group>"; };
 		921695062BF26F23006DC44A /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
+		921695082BF302D2006DC44A /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -70,6 +72,7 @@
 		921694EC2BF1BA8E006DC44A /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				921695082BF302D2006DC44A /* LoginViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -247,6 +250,7 @@
 			files = (
 				921694FA2BF21F07006DC44A /* RequestBuilder.swift in Sources */,
 				921695012BF220A6006DC44A /* NetworkError.swift in Sources */,
+				921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */,
 				92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */,
 				921694FE2BF2207A006DC44A /* APIProvider.swift in Sources */,
 				921694F82BF21E70006DC44A /* HTTP.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -16,6 +16,10 @@
 		921695072BF26F23006DC44A /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695062BF26F23006DC44A /* APIConstants.swift */; };
 		921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695082BF302D2006DC44A /* LoginViewModel.swift */; };
 		9216950F2BF33E9D006DC44A /* LoginDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9216950E2BF33E9D006DC44A /* LoginDTO.swift */; };
+		921695112BF34256006DC44A /* LoginRepositoryType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695102BF34256006DC44A /* LoginRepositoryType.swift */; };
+		921695132BF34995006DC44A /* LoginProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695122BF34995006DC44A /* LoginProvider.swift */; };
+		921695152BF35377006DC44A /* LoginRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695142BF35377006DC44A /* LoginRepository.swift */; };
+		9216951C2BF3CEBC006DC44A /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9216951B2BF3CEBC006DC44A /* LoginUseCase.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -34,6 +38,10 @@
 		921695062BF26F23006DC44A /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		921695082BF302D2006DC44A /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
 		9216950E2BF33E9D006DC44A /* LoginDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDTO.swift; sourceTree = "<group>"; };
+		921695102BF34256006DC44A /* LoginRepositoryType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepositoryType.swift; sourceTree = "<group>"; };
+		921695122BF34995006DC44A /* LoginProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginProvider.swift; sourceTree = "<group>"; };
+		921695142BF35377006DC44A /* LoginRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginRepository.swift; sourceTree = "<group>"; };
+		9216951B2BF3CEBC006DC44A /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -112,6 +120,7 @@
 			isa = PBXGroup;
 			children = (
 				921695062BF26F23006DC44A /* APIConstants.swift */,
+				921695122BF34995006DC44A /* LoginProvider.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -155,6 +164,7 @@
 		9216950A2BF31799006DC44A /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				921695102BF34256006DC44A /* LoginRepositoryType.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -162,6 +172,7 @@
 		9216950B2BF317AC006DC44A /* UseCase */ = {
 			isa = PBXGroup;
 			children = (
+				9216951B2BF3CEBC006DC44A /* LoginUseCase.swift */,
 			);
 			path = UseCase;
 			sourceTree = "<group>";
@@ -169,6 +180,7 @@
 		9216950C2BF317CE006DC44A /* Repository */ = {
 			isa = PBXGroup;
 			children = (
+				921695142BF35377006DC44A /* LoginRepository.swift */,
 			);
 			path = Repository;
 			sourceTree = "<group>";
@@ -283,10 +295,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				921695132BF34995006DC44A /* LoginProvider.swift in Sources */,
 				921694FA2BF21F07006DC44A /* RequestBuilder.swift in Sources */,
 				9216950F2BF33E9D006DC44A /* LoginDTO.swift in Sources */,
 				921695012BF220A6006DC44A /* NetworkError.swift in Sources */,
 				921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */,
+				921695152BF35377006DC44A /* LoginRepository.swift in Sources */,
 				92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */,
 				921694FE2BF2207A006DC44A /* APIProvider.swift in Sources */,
 				921694F82BF21E70006DC44A /* HTTP.swift in Sources */,
@@ -294,7 +308,9 @@
 				921695072BF26F23006DC44A /* APIConstants.swift in Sources */,
 				921695042BF22DCD006DC44A /* UIImage+.swift in Sources */,
 				92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */,
+				921695112BF34256006DC44A /* LoginRepositoryType.swift in Sources */,
 				921694FC2BF2202A006DC44A /* URLBuilder.swift in Sources */,
+				9216951C2BF3CEBC006DC44A /* LoginUseCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		921694FE2BF2207A006DC44A /* APIProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921694FD2BF2207A006DC44A /* APIProvider.swift */; };
 		921695012BF220A6006DC44A /* NetworkError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695002BF220A6006DC44A /* NetworkError.swift */; };
 		921695042BF22DCD006DC44A /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695032BF22DCD006DC44A /* UIImage+.swift */; };
+		921695072BF26F23006DC44A /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695062BF26F23006DC44A /* APIConstants.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -28,6 +29,7 @@
 		921695002BF220A6006DC44A /* NetworkError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkError.swift; sourceTree = "<group>"; };
 		921695032BF22DCD006DC44A /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		921695052BF26E73006DC44A /* roome.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = roome.entitlements; sourceTree = "<group>"; };
+		921695062BF26F23006DC44A /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -100,6 +102,7 @@
 		921694F02BF1BEA5006DC44A /* Network */ = {
 			isa = PBXGroup;
 			children = (
+				921695062BF26F23006DC44A /* APIConstants.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -248,6 +251,7 @@
 				921694FE2BF2207A006DC44A /* APIProvider.swift in Sources */,
 				921694F82BF21E70006DC44A /* HTTP.swift in Sources */,
 				92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */,
+				921695072BF26F23006DC44A /* APIConstants.swift in Sources */,
 				921695042BF22DCD006DC44A /* UIImage+.swift in Sources */,
 				92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */,
 				921694FC2BF2202A006DC44A /* URLBuilder.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		921695042BF22DCD006DC44A /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695032BF22DCD006DC44A /* UIImage+.swift */; };
 		921695072BF26F23006DC44A /* APIConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695062BF26F23006DC44A /* APIConstants.swift */; };
 		921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695082BF302D2006DC44A /* LoginViewModel.swift */; };
+		9216950F2BF33E9D006DC44A /* LoginDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9216950E2BF33E9D006DC44A /* LoginDTO.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -32,6 +33,7 @@
 		921695052BF26E73006DC44A /* roome.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = roome.entitlements; sourceTree = "<group>"; };
 		921695062BF26F23006DC44A /* APIConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIConstants.swift; sourceTree = "<group>"; };
 		921695082BF302D2006DC44A /* LoginViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewModel.swift; sourceTree = "<group>"; };
+		9216950E2BF33E9D006DC44A /* LoginDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginDTO.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -174,6 +176,7 @@
 		9216950D2BF33DA7006DC44A /* DataMaping */ = {
 			isa = PBXGroup;
 			children = (
+				9216950E2BF33E9D006DC44A /* LoginDTO.swift */,
 			);
 			path = DataMaping;
 			sourceTree = "<group>";
@@ -281,6 +284,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				921694FA2BF21F07006DC44A /* RequestBuilder.swift in Sources */,
+				9216950F2BF33E9D006DC44A /* LoginDTO.swift in Sources */,
 				921695012BF220A6006DC44A /* NetworkError.swift in Sources */,
 				921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */,
 				92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -90,6 +90,8 @@
 		921694EE2BF1BBD1006DC44A /* Domain */ = {
 			isa = PBXGroup;
 			children = (
+				9216950A2BF31799006DC44A /* Repository */,
+				9216950B2BF317AC006DC44A /* UseCase */,
 			);
 			path = Domain;
 			sourceTree = "<group>";
@@ -97,6 +99,8 @@
 		921694EF2BF1BDD7006DC44A /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				9216950D2BF33DA7006DC44A /* DataMaping */,
+				9216950C2BF317CE006DC44A /* Repository */,
 				921694F02BF1BEA5006DC44A /* Network */,
 			);
 			path = Data;
@@ -144,6 +148,34 @@
 				921695032BF22DCD006DC44A /* UIImage+.swift */,
 			);
 			path = Extension;
+			sourceTree = "<group>";
+		};
+		9216950A2BF31799006DC44A /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		9216950B2BF317AC006DC44A /* UseCase */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = UseCase;
+			sourceTree = "<group>";
+		};
+		9216950C2BF317CE006DC44A /* Repository */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Repository;
+			sourceTree = "<group>";
+		};
+		9216950D2BF33DA7006DC44A /* DataMaping */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = DataMaping;
 			sourceTree = "<group>";
 		};
 		92DBD9F62BCFCF5900E299E2 = {

--- a/roome/roome/Application/SceneDelegate.swift
+++ b/roome/roome/Application/SceneDelegate.swift
@@ -19,7 +19,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = LoginViewController()
+        window?.rootViewController = LoginViewController(viewModel: LoginViewModel(loginUseCase: LoginUseCase(loginRepository: LoginRepository())))
         window?.makeKeyAndVisible()
     }
 

--- a/roome/roome/Data/DataMaping/LoginDTO.swift
+++ b/roome/roome/Data/DataMaping/LoginDTO.swift
@@ -1,0 +1,17 @@
+//
+//  LoginDTO.swift
+//  roome
+//
+//  Created by minsong kim on 5/14/24.
+//
+
+struct LoginDTO: Decodable {
+    let code: Int
+    let message: String
+    let data: Tokens
+
+    struct Tokens: Decodable {
+        let accessToken: String
+        let refreshToken: String
+    }
+}

--- a/roome/roome/Data/DataMaping/LoginDTO.swift
+++ b/roome/roome/Data/DataMaping/LoginDTO.swift
@@ -5,12 +5,12 @@
 //  Created by minsong kim on 5/14/24.
 //
 
-struct LoginDTO: Decodable {
+struct LoginDTO: Codable {
     let code: Int
     let message: String
     let data: Tokens
 
-    struct Tokens: Decodable {
+    struct Tokens: Codable {
         let accessToken: String
         let refreshToken: String
     }

--- a/roome/roome/Data/Network/APIConstants.swift
+++ b/roome/roome/Data/Network/APIConstants.swift
@@ -1,0 +1,24 @@
+//
+//  APIConstants.swift
+//  roome
+//
+//  Created by minsong kim on 5/14/24.
+//
+
+struct APIConstants {
+    static let roomeHost = "roome.site"
+    
+    enum Path {
+        case signIn
+        case withdrawal
+        
+        var name: String {
+            switch self {
+            case .signIn:
+                "/signin"
+            case.withdrawal:
+                "/withdrawal"
+            }
+        }
+    }
+}

--- a/roome/roome/Data/Network/LoginProvider.swift
+++ b/roome/roome/Data/Network/LoginProvider.swift
@@ -1,0 +1,22 @@
+//
+//  LoginProvider.swift
+//  roome
+//
+//  Created by minsong kim on 5/14/24.
+//
+
+import Foundation
+
+enum LoginProvider {
+    case apple
+    case kakao
+    
+    var name: String {
+        switch self {
+        case .apple:
+            return "apple"
+        case .kakao:
+            return "kakao"
+        }
+    }
+}

--- a/roome/roome/Data/Repository/LoginRepository.swift
+++ b/roome/roome/Data/Repository/LoginRepository.swift
@@ -1,0 +1,33 @@
+//
+//  LoginRepository.swift
+//  roome
+//
+//  Created by minsong kim on 5/14/24.
+//
+
+import Foundation
+
+class LoginRepository: LoginRepositoryType {
+    func requestLogin(body json: [String: Any], decodedDataType: LoginDTO.Type) async -> LoginDTO? {
+        let loginURL = URLBuilder(host: APIConstants.roomeHost, path: APIConstants.Path.signIn.name, queries: nil)
+        guard let url = loginURL.url else {
+            return nil
+        }
+        
+        let requestBuilder = RequestBuilder(url: url, method: .post, bodyJSON: json)
+        guard let request = requestBuilder.create() else {
+            return nil
+        }
+
+        do {
+            let token = try await APIProvider().fetchDecodedData(type: decodedDataType.self, from: request)
+            print("login success")
+            print(token)
+            return token
+        } catch {
+            print(error)
+        }
+        
+        return nil
+    }
+}

--- a/roome/roome/Domain/Repository/LoginRepositoryType.swift
+++ b/roome/roome/Domain/Repository/LoginRepositoryType.swift
@@ -1,0 +1,14 @@
+//
+//  LoginRepositoryType.swift
+//  roome
+//
+//  Created by minsong kim on 5/14/24.
+//
+
+import Foundation
+
+protocol LoginRepositoryType {
+//    private let loginRepository: LoginRepository
+    
+    func requestLogin(body json: [String: Any], decodedDataType: LoginDTO.Type) async -> LoginDTO?
+}

--- a/roome/roome/Domain/UseCase/LoginUseCase.swift
+++ b/roome/roome/Domain/UseCase/LoginUseCase.swift
@@ -1,0 +1,37 @@
+//
+//  LoginUseCase.swift
+//  roome
+//
+//  Created by minsong kim on 5/15/24.
+//
+
+import Foundation
+
+class LoginUseCase {
+    private let loginRepository: LoginRepositoryType
+    
+    init(loginRepository: LoginRepositoryType) {
+        self.loginRepository = loginRepository
+    }
+    
+    func loginWithAPI(body json: [String: Any], decodedDataType: LoginDTO.Type) async {
+        guard let tokens = await loginRepository.requestLogin(body: json, decodedDataType: decodedDataType) else {
+            return
+        }
+        
+        let query: NSDictionary = [kSecClass: kSecClassGenericPassword,
+                             kSecAttrAccount: tokens.data.accessToken,
+                               kSecAttrLabel: tokens.data.refreshToken]
+        SecItemDelete(query)
+        
+        let status = SecItemAdd(query, nil)
+        print(status)
+        
+        if status == errSecSuccess {
+            print("success")
+        } else {
+            print("failure")
+        }
+    }
+    
+}

--- a/roome/roome/Presentation/View/LoginViewController.swift
+++ b/roome/roome/Presentation/View/LoginViewController.swift
@@ -9,8 +9,17 @@ import UIKit
 import Combine
 
 class LoginViewController: UIViewController {
-    private var viewModel: LoginViewModel?
+    private var viewModel: LoginViewModel
     private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: LoginViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
     
     let stackView: UIStackView = {
         let stack = UIStackView()
@@ -49,7 +58,6 @@ class LoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
-        viewModel = LoginViewModel()
         bind()
     }
     
@@ -72,11 +80,11 @@ class LoginViewController: UIViewController {
     
     @objc
     private func pushedAppleLoginButton() {
-        viewModel?.pushedAppleLoginButton()
+        viewModel.pushedAppleLoginButton()
     }
     
     private func bind() {
-        viewModel?.loginPublisher
+        viewModel.loginPublisher
             .sink(receiveCompletion: { completion in
                 switch completion {
                 case .finished:

--- a/roome/roome/Presentation/View/LoginViewController.swift
+++ b/roome/roome/Presentation/View/LoginViewController.swift
@@ -6,8 +6,12 @@
 //
 
 import UIKit
+import Combine
 
 class LoginViewController: UIViewController {
+    private var viewModel: LoginViewModel?
+    private var cancellables = Set<AnyCancellable>()
+    
     let stackView: UIStackView = {
         let stack = UIStackView()
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -45,6 +49,8 @@ class LoginViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
+        viewModel = LoginViewModel()
+        bind()
     }
     
     private func configureUI() {
@@ -66,6 +72,20 @@ class LoginViewController: UIViewController {
     
     @objc
     private func pushedAppleLoginButton() {
-        
+        viewModel?.pushedAppleLoginButton()
+    }
+    
+    private func bind() {
+        viewModel?.loginPublisher
+            .sink(receiveCompletion: { completion in
+                switch completion {
+                case .finished:
+                    print("finished")
+                case .failure(let failure):
+                    print("\(failure)")
+                }
+            }, receiveValue: { _ in
+                print("로그인 성공")
+            }).store(in: &cancellables)
     }
 }

--- a/roome/roome/Presentation/ViewModel/LoginViewModel.swift
+++ b/roome/roome/Presentation/ViewModel/LoginViewModel.swift
@@ -1,0 +1,46 @@
+//
+//  LoginViewModel.swift
+//  roome
+//
+//  Created by minsong kim on 5/14/24.
+//
+
+import Foundation
+import Combine
+import AuthenticationServices
+
+protocol LoginViewModelInput {
+    func pushedAppleLoginButton()
+}
+
+protocol LoginViewModelOutput {
+    var loginPublisher: PassthroughSubject<Void, Error> { get set}
+}
+
+class LoginViewModel: NSObject, LoginViewModelInput, LoginViewModelOutput {
+    var loginPublisher = PassthroughSubject<Void, Error>()
+    
+    override init() {
+        super.init()
+    }
+    
+    func pushedAppleLoginButton() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.performRequests()
+    }
+}
+
+extension LoginViewModel: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            return
+        }
+        
+        loginPublisher.send()
+    }
+}

--- a/roome/roome/roome.entitlements
+++ b/roome/roome/roome.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
## 🔥 트러블 슈팅
### 1️⃣. keychain osstatus -50
키체인에 서버에서 받은 엑세스 토큰과 리프레쉬 토큰을 저장할 때 osstatus code가 -50이 뜨면서 실패했다. 
-> kSecClass의 kSecClassGenericPassword에서는 사용가능한 attribute에 kSecValueRef가 없다… 
내용을 저장하려면 추후에 kSecValueData에 JSON Encoding을 통해 저장해야 한다. 
현재는 그저 query 값으로 들어있다.

### 2️⃣. Repository, UseCase
도메인의 Repository에는 인터페이스(protocol)
Data의 Repository는 구현체(class),
도메인의 UseCase는 protocol Repository를 가지는 구현체(class)

## 🆘 Issue
close #4 