### PR TITLE
View/terms of service

### DIFF
--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		921695412BF9008A006DC44A /* TermsOfServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */; };
 		921695462BF9B661006DC44A /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695452BF9B661006DC44A /* PaddingLabel.swift */; };
 		921695482BF9FC5B006DC44A /* LabelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695472BF9FC5B006DC44A /* LabelButton.swift */; };
+		9216954A2BFA1A9D006DC44A /* TermsOfServiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695492BFA1A9D006DC44A /* TermsOfServiceViewModel.swift */; };
 		9216954C2BFA65EE006DC44A /* UIControl+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9216954B2BFA65EE006DC44A /* UIControl+.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
@@ -71,6 +72,7 @@
 		921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewController.swift; sourceTree = "<group>"; };
 		921695452BF9B661006DC44A /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		921695472BF9FC5B006DC44A /* LabelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelButton.swift; sourceTree = "<group>"; };
+		921695492BFA1A9D006DC44A /* TermsOfServiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewModel.swift; sourceTree = "<group>"; };
 		9216954B2BFA65EE006DC44A /* UIControl+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+.swift"; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -118,6 +120,7 @@
 			children = (
 				921695082BF302D2006DC44A /* LoginViewModel.swift */,
 				921695352BF79BB7006DC44A /* NicknameViewModel.swift */,
+				921695492BFA1A9D006DC44A /* TermsOfServiceViewModel.swift */,
 			);
 			path = ViewModel;
 			sourceTree = "<group>";
@@ -431,6 +434,7 @@
 				921695072BF26F23006DC44A /* APIConstants.swift in Sources */,
 				921695042BF22DCD006DC44A /* UIImage+.swift in Sources */,
 				92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */,
+				9216954A2BFA1A9D006DC44A /* TermsOfServiceViewModel.swift in Sources */,
 				921695112BF34256006DC44A /* LoginRepositoryType.swift in Sources */,
 				921694FC2BF2202A006DC44A /* URLBuilder.swift in Sources */,
 				9216951C2BF3CEBC006DC44A /* LoginUseCase.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		921695412BF9008A006DC44A /* TermsOfServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */; };
 		921695462BF9B661006DC44A /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695452BF9B661006DC44A /* PaddingLabel.swift */; };
 		921695482BF9FC5B006DC44A /* LabelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695472BF9FC5B006DC44A /* LabelButton.swift */; };
+		9216954C2BFA65EE006DC44A /* UIControl+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9216954B2BFA65EE006DC44A /* UIControl+.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -70,6 +71,7 @@
 		921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewController.swift; sourceTree = "<group>"; };
 		921695452BF9B661006DC44A /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		921695472BF9FC5B006DC44A /* LabelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelButton.swift; sourceTree = "<group>"; };
+		9216954B2BFA65EE006DC44A /* UIControl+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIControl+.swift"; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -192,6 +194,7 @@
 			isa = PBXGroup;
 			children = (
 				921695032BF22DCD006DC44A /* UIImage+.swift */,
+				9216954B2BFA65EE006DC44A /* UIControl+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -412,6 +415,7 @@
 				9216950F2BF33E9D006DC44A /* LoginDTO.swift in Sources */,
 				921695012BF220A6006DC44A /* NetworkError.swift in Sources */,
 				921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */,
+				9216954C2BFA65EE006DC44A /* UIControl+.swift in Sources */,
 				921695152BF35377006DC44A /* LoginRepository.swift in Sources */,
 				921695342BF765F2006DC44A /* NicknameViewController.swift in Sources */,
 				921695302BF71659006DC44A /* FontSize.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		921695362BF79BB7006DC44A /* NicknameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695352BF79BB7006DC44A /* NicknameViewModel.swift */; };
 		921695382BF84604006DC44A /* NicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695372BF84604006DC44A /* NicknameUseCase.swift */; };
 		9216953A2BF88FBB006DC44A /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695392BF88FBB006DC44A /* UITextField+.swift */; };
+		921695412BF9008A006DC44A /* TermsOfServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */; };
 		921695462BF9B661006DC44A /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695452BF9B661006DC44A /* PaddingLabel.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
@@ -65,6 +66,7 @@
 		921695352BF79BB7006DC44A /* NicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewModel.swift; sourceTree = "<group>"; };
 		921695372BF84604006DC44A /* NicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameUseCase.swift; sourceTree = "<group>"; };
 		921695392BF88FBB006DC44A /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
+		921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewController.swift; sourceTree = "<group>"; };
 		921695452BF9B661006DC44A /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -265,6 +267,7 @@
 			isa = PBXGroup;
 			children = (
 				921695332BF765F2006DC44A /* NicknameViewController.swift */,
+				921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -416,6 +419,7 @@
 				921695322BF7450E006DC44A /* UIFont+.swift in Sources */,
 				921695362BF79BB7006DC44A /* NicknameViewModel.swift in Sources */,
 				92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */,
+				921695412BF9008A006DC44A /* TermsOfServiceViewController.swift in Sources */,
 				921695072BF26F23006DC44A /* APIConstants.swift in Sources */,
 				921695042BF22DCD006DC44A /* UIImage+.swift in Sources */,
 				92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		921695362BF79BB7006DC44A /* NicknameViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695352BF79BB7006DC44A /* NicknameViewModel.swift */; };
 		921695382BF84604006DC44A /* NicknameUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695372BF84604006DC44A /* NicknameUseCase.swift */; };
 		9216953A2BF88FBB006DC44A /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695392BF88FBB006DC44A /* UITextField+.swift */; };
+		921695462BF9B661006DC44A /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695452BF9B661006DC44A /* PaddingLabel.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -64,6 +65,7 @@
 		921695352BF79BB7006DC44A /* NicknameViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameViewModel.swift; sourceTree = "<group>"; };
 		921695372BF84604006DC44A /* NicknameUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameUseCase.swift; sourceTree = "<group>"; };
 		921695392BF88FBB006DC44A /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
+		921695452BF9B661006DC44A /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -117,6 +119,7 @@
 		921694ED2BF1BB8B006DC44A /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				921695442BF9B64E006DC44A /* CustomUI */,
 				92DBDA0D2BCFCF5B00E299E2 /* LaunchScreen.storyboard */,
 				921695022BF22DB4006DC44A /* Extension */,
 				921694E92BF1BA74006DC44A /* View */,
@@ -274,6 +277,14 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		921695442BF9B64E006DC44A /* CustomUI */ = {
+			isa = PBXGroup;
+			children = (
+				921695452BF9B661006DC44A /* PaddingLabel.swift */,
+			);
+			path = CustomUI;
+			sourceTree = "<group>";
+		};
 		92DBD9F62BCFCF5900E299E2 = {
 			isa = PBXGroup;
 			children = (
@@ -400,6 +411,7 @@
 				921695302BF71659006DC44A /* FontSize.swift in Sources */,
 				92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */,
 				921694FE2BF2207A006DC44A /* APIProvider.swift in Sources */,
+				921695462BF9B661006DC44A /* PaddingLabel.swift in Sources */,
 				921694F82BF21E70006DC44A /* HTTP.swift in Sources */,
 				921695322BF7450E006DC44A /* UIFont+.swift in Sources */,
 				921695362BF79BB7006DC44A /* NicknameViewModel.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		9216953A2BF88FBB006DC44A /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695392BF88FBB006DC44A /* UITextField+.swift */; };
 		921695412BF9008A006DC44A /* TermsOfServiceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */; };
 		921695462BF9B661006DC44A /* PaddingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695452BF9B661006DC44A /* PaddingLabel.swift */; };
+		921695482BF9FC5B006DC44A /* LabelButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 921695472BF9FC5B006DC44A /* LabelButton.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -68,6 +69,7 @@
 		921695392BF88FBB006DC44A /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		921695402BF9008A006DC44A /* TermsOfServiceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsOfServiceViewController.swift; sourceTree = "<group>"; };
 		921695452BF9B661006DC44A /* PaddingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaddingLabel.swift; sourceTree = "<group>"; };
+		921695472BF9FC5B006DC44A /* LabelButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabelButton.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -284,6 +286,7 @@
 			isa = PBXGroup;
 			children = (
 				921695452BF9B661006DC44A /* PaddingLabel.swift */,
+				921695472BF9FC5B006DC44A /* LabelButton.swift */,
 			);
 			path = CustomUI;
 			sourceTree = "<group>";
@@ -419,6 +422,7 @@
 				921695322BF7450E006DC44A /* UIFont+.swift in Sources */,
 				921695362BF79BB7006DC44A /* NicknameViewModel.swift in Sources */,
 				92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */,
+				921695482BF9FC5B006DC44A /* LabelButton.swift in Sources */,
 				921695412BF9008A006DC44A /* TermsOfServiceViewController.swift in Sources */,
 				921695072BF26F23006DC44A /* APIConstants.swift in Sources */,
 				921695042BF22DCD006DC44A /* UIImage+.swift in Sources */,

--- a/roome/roome/Presentation/CustomUI/LabelButton.swift
+++ b/roome/roome/Presentation/CustomUI/LabelButton.swift
@@ -1,0 +1,91 @@
+//
+//  LabelButton.swift
+//  roome
+//
+//  Created by minsong kim on 5/19/24.
+//
+
+import UIKit
+
+class LabelButton: UIButton {
+    private let serviceLineStackView: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.alignment = .center
+        stack.distribution = .equalSpacing
+        stack.spacing = 12
+        
+        return stack
+    }()
+    
+    private let mainButton: UIButton = {
+        let button = UIButton()
+        button.contentHorizontalAlignment = .leading
+        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    
+    private let detailButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "chevron.right")?.resize(newWidth: 12).changeImageColor(.systemGray4)
+        configuration.imagePadding = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 0, bottom: 5, trailing: 20)
+        
+        let button = UIButton(configuration: configuration)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private var isDetailButton: Bool
+    
+    init(frame: CGRect, isDetailButton: Bool) {
+        self.isDetailButton = isDetailButton
+        super.init(frame: .zero)
+        
+        if isDetailButton {
+            setDetail()
+        } else {
+            setMain()
+        }
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setMain(config: UIButton.Configuration) {
+        mainButton.configuration = config
+    }
+    
+    func setDetail() {
+        self.addSubview(mainButton)
+        self.addSubview(detailButton)
+        
+        NSLayoutConstraint.activate([
+            detailButton.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            detailButton.topAnchor.constraint(equalTo: self.topAnchor),
+            detailButton.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            
+            mainButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            mainButton.topAnchor.constraint(equalTo: self.topAnchor),
+            mainButton.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            mainButton.trailingAnchor.constraint(equalTo: detailButton.leadingAnchor),
+        ])
+        mainButton.setContentHuggingPriority(.init(100), for: .horizontal)
+    }
+    
+    func setMain() {
+        self.addSubview(mainButton)
+        
+        NSLayoutConstraint.activate([
+            mainButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
+            mainButton.topAnchor.constraint(equalTo: self.topAnchor),
+            mainButton.bottomAnchor.constraint(equalTo: self.bottomAnchor),
+            mainButton.trailingAnchor.constraint(equalTo: self.leadingAnchor)
+        ])
+    }
+}

--- a/roome/roome/Presentation/CustomUI/LabelButton.swift
+++ b/roome/roome/Presentation/CustomUI/LabelButton.swift
@@ -6,18 +6,9 @@
 //
 
 import UIKit
+import Combine
 
-class LabelButton: UIButton {
-    private let serviceLineStackView: UIStackView = {
-        let stack = UIStackView()
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.alignment = .center
-        stack.distribution = .equalSpacing
-        stack.spacing = 12
-        
-        return stack
-    }()
-    
+class LabelButton: UIView {
     private let mainButton: UIButton = {
         let button = UIButton()
         button.contentHorizontalAlignment = .leading
@@ -57,8 +48,18 @@ class LabelButton: UIButton {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func tappedMainButtonPublisher() -> AnyPublisher<Void, Never> {
+        mainButton.publisher(for: .touchUpInside)
+            .eraseToAnyPublisher()
+    }
+    
     func setMain(config: UIButton.Configuration) {
         mainButton.configuration = config
+        mainButton.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+    }
+    
+    func updateImageColor(_ color: UIColor) {
+        mainButton.configuration?.image = UIImage(systemName: "checkmark")?.resize(newWidth: 16).changeImageColor(color)
     }
     
     func setDetail() {
@@ -85,7 +86,7 @@ class LabelButton: UIButton {
             mainButton.leadingAnchor.constraint(equalTo: self.leadingAnchor),
             mainButton.topAnchor.constraint(equalTo: self.topAnchor),
             mainButton.bottomAnchor.constraint(equalTo: self.bottomAnchor),
-            mainButton.trailingAnchor.constraint(equalTo: self.leadingAnchor)
+            mainButton.trailingAnchor.constraint(equalTo: self.trailingAnchor)
         ])
     }
 }

--- a/roome/roome/Presentation/CustomUI/PaddingLabel.swift
+++ b/roome/roome/Presentation/CustomUI/PaddingLabel.swift
@@ -1,0 +1,29 @@
+//
+//  PaddingLabel.swift
+//  roome
+//
+//  Created by minsong kim on 5/19/24.
+//
+
+import UIKit
+
+class PaddingLabel: UILabel {
+    private var padding = UIEdgeInsets(top: 4.0, left: 12.0, bottom: 4.0, right: 12.0)
+
+    convenience init(padding: UIEdgeInsets) {
+        self.init()
+        self.padding = padding
+    }
+
+    override func drawText(in rect: CGRect) {
+        super.drawText(in: rect.inset(by: padding))
+    }
+
+    override var intrinsicContentSize: CGSize {
+        var contentSize = super.intrinsicContentSize
+        contentSize.height += padding.top + padding.bottom
+        contentSize.width += padding.left + padding.right
+
+        return contentSize
+    }
+}

--- a/roome/roome/Presentation/Extension/UIControl+.swift
+++ b/roome/roome/Presentation/Extension/UIControl+.swift
@@ -1,0 +1,59 @@
+//
+//  UIControl+.swift
+//  roome
+//
+//  Created by minsong kim on 5/20/24.
+//
+
+import UIKit
+import Combine
+
+extension UIControl {
+    struct EventPublisher: Publisher {
+        typealias Output = Void
+        typealias Failure = Never
+
+        fileprivate var control: UIControl
+        fileprivate var event: Event
+
+        func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
+            let subscription = EventSubscription<S>()
+            subscription.target = subscriber
+
+            subscriber.receive(subscription: subscription)
+
+            control.addTarget(
+                subscription,
+                action: #selector(subscription.trigger),
+                for: event
+            )
+        }
+    }
+}
+
+private extension UIControl {
+    class EventSubscription<Target: Subscriber>: Subscription where Target.Input == Void {
+
+        var target: Target?
+
+        func request( _ demand: Subscribers.Demand) { }
+
+        func cancel() {
+            target = nil
+        }
+
+        @objc
+        func trigger() {
+            _ = target?.receive(())
+        }
+    }
+}
+
+extension UIControl {
+    func publisher(for event: Event) -> EventPublisher {
+        EventPublisher(
+            control: self,
+            event: event
+        )
+    }
+}

--- a/roome/roome/Presentation/Extension/UIImage+.swift
+++ b/roome/roome/Presentation/Extension/UIImage+.swift
@@ -20,4 +20,23 @@ extension UIImage {
         
         return renderImage
     }
+    
+    func changeImageColor(_ color: UIColor) -> UIImage {
+        UIGraphicsBeginImageContextWithOptions(self.size, false, self.scale)
+        color.setFill()
+
+        let context = UIGraphicsGetCurrentContext()
+        context?.translateBy(x: 0, y: self.size.height)
+        context?.scaleBy(x: 1.0, y: -1.0)
+        context?.setBlendMode(CGBlendMode.normal)
+
+        let rect = CGRect(origin: .zero, size: CGSize(width: self.size.width, height: self.size.height))
+        context?.clip(to: rect, mask: self.cgImage!)
+        context?.fill(rect)
+
+        let newImage = UIGraphicsGetImageFromCurrentImageContext()
+        UIGraphicsEndImageContext()
+
+        return newImage!
+    }
 }

--- a/roome/roome/Presentation/View/SignUp/ViewController/TermsOfServiceViewController.swift
+++ b/roome/roome/Presentation/View/SignUp/ViewController/TermsOfServiceViewController.swift
@@ -25,6 +25,7 @@ class TermsOfServiceViewController: UIViewController {
         label.numberOfLines = 2
         label.sizeToFit()
         label.textAlignment = .left
+        label.textColor = .label
         label.font = UIFont().pretendardBold(size: .headline2)
         label.translatesAutoresizingMaskIntoConstraints = false
         
@@ -33,7 +34,7 @@ class TermsOfServiceViewController: UIViewController {
     
     private let allAgreeButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
-        configuration.baseForegroundColor = .black
+        configuration.baseForegroundColor = .label
         configuration.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.lightGray).resize(newWidth: 24)
         configuration.imagePadding = 8
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 15, leading: 15, bottom: 10, trailing: 20)
@@ -48,7 +49,7 @@ class TermsOfServiceViewController: UIViewController {
     
     private let ageAgreeButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
-        configuration.baseForegroundColor = .black
+        configuration.baseForegroundColor = .label
         configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
         configuration.imagePadding = 12
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
@@ -63,14 +64,14 @@ class TermsOfServiceViewController: UIViewController {
     
     private let serviceAgreeButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
-        configuration.baseForegroundColor = .black
+        configuration.baseForegroundColor = .label
         configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
         configuration.imagePadding = 12
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
         configuration.title = "서비스 이용약관에 동의 (필수)"
         
-        let button = UIButton(configuration: configuration)
-        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        let button = LabelButton(frame: .zero, isDetailButton: true)
+        button.setMain(config: configuration)
         button.translatesAutoresizingMaskIntoConstraints = false
         
         return button
@@ -78,14 +79,14 @@ class TermsOfServiceViewController: UIViewController {
     
     private let personalInformationAgreeButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
-        configuration.baseForegroundColor = .black
+        configuration.baseForegroundColor = .label
         configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
         configuration.imagePadding = 12
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
         configuration.title = "개인정보 수집 및 이용약관에 동의 (필수)"
         
-        let button = UIButton(configuration: configuration)
-        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        let button = LabelButton(frame: .zero, isDetailButton: true)
+        button.setMain(config: configuration)
         button.translatesAutoresizingMaskIntoConstraints = false
         
         return button
@@ -93,14 +94,14 @@ class TermsOfServiceViewController: UIViewController {
     
     private let advertiseAgreeButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
-        configuration.baseForegroundColor = .black
+        configuration.baseForegroundColor = .label
         configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
         configuration.imagePadding = 12
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
         configuration.title = "광고 및 마케팅 수신에 동의 (선택)"
         
-        let button = UIButton(configuration: configuration)
-        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        let button = LabelButton(frame: .zero, isDetailButton: true)
+        button.setMain(config: configuration)
         button.translatesAutoresizingMaskIntoConstraints = false
         
         return button
@@ -139,6 +140,16 @@ class TermsOfServiceViewController: UIViewController {
             stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
             stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 24),
+            
+            serviceAgreeButton.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            serviceAgreeButton.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            
+            personalInformationAgreeButton.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            personalInformationAgreeButton.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            
+            advertiseAgreeButton.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
+            advertiseAgreeButton.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
+            
         ])
     }
 

--- a/roome/roome/Presentation/View/SignUp/ViewController/TermsOfServiceViewController.swift
+++ b/roome/roome/Presentation/View/SignUp/ViewController/TermsOfServiceViewController.swift
@@ -1,0 +1,155 @@
+//
+//  TermsOfServiceViewController.swift
+//  roome
+//
+//  Created by minsong kim on 5/19/24.
+//
+
+import UIKit
+
+class TermsOfServiceViewController: UIViewController {
+    private let stackView: UIStackView = {
+        let stack = UIStackView()
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.axis = .vertical
+        stack.alignment = .leading
+        stack.distribution = .equalSpacing
+        stack.spacing = 12
+        
+        return stack
+    }()
+    
+    private let titleLabel: PaddingLabel = {
+        let label = PaddingLabel()
+        label.text = "서비스 이용약관"
+        label.numberOfLines = 2
+        label.sizeToFit()
+        label.textAlignment = .left
+        label.font = UIFont().pretendardBold(size: .headline2)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let allAgreeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .black
+        configuration.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.lightGray).resize(newWidth: 24)
+        configuration.imagePadding = 8
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 15, leading: 15, bottom: 10, trailing: 20)
+        configuration.title = "모두 동의(선택 정보 포함)"
+        
+        let button = UIButton(configuration: configuration)
+        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let ageAgreeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .black
+        configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
+        configuration.imagePadding = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
+        configuration.title = "만 14세 이상입니다.(필수)"
+        
+        let button = UIButton(configuration: configuration)
+        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let serviceAgreeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .black
+        configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
+        configuration.imagePadding = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
+        configuration.title = "서비스 이용약관에 동의 (필수)"
+        
+        let button = UIButton(configuration: configuration)
+        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let personalInformationAgreeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .black
+        configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
+        configuration.imagePadding = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
+        configuration.title = "개인정보 수집 및 이용약관에 동의 (필수)"
+        
+        let button = UIButton(configuration: configuration)
+        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let advertiseAgreeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .black
+        configuration.image = UIImage(systemName: "checkmark")?.changeImageColor( .lightGray).resize(newWidth: 12)
+        configuration.imagePadding = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 5, leading: 20, bottom: 5, trailing: 20)
+        configuration.title = "광고 및 마케팅 수신에 동의 (선택)"
+        
+        let button = UIButton(configuration: configuration)
+        button.titleLabel?.font = UIFont().pretendardMedium(size: .label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let nextButton: UIButton = {
+        let button = UIButton(type: .system)
+        button.isEnabled = false
+        button.tintColor = .white
+        button.layer.cornerRadius = 10
+        button.backgroundColor = .gray
+        button.setTitle("다음", for: .normal)
+        button.titleLabel?.font = UIFont().pretendardBold(size: .label)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureStackView()
+        configureNextButton()
+    }
+    
+    private func configureStackView() {
+        stackView.addArrangedSubview(titleLabel)
+        stackView.addArrangedSubview(allAgreeButton)
+        stackView.addArrangedSubview(ageAgreeButton)
+        stackView.addArrangedSubview(serviceAgreeButton)
+        stackView.addArrangedSubview(personalInformationAgreeButton)
+        stackView.addArrangedSubview(advertiseAgreeButton)
+        
+        view.addSubview(stackView)
+        
+        NSLayoutConstraint.activate([
+            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 12),
+            stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            stackView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 24),
+        ])
+    }
+
+    private func configureNextButton() {
+        view.addSubview(nextButton)
+        
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            nextButton.heightAnchor.constraint(equalTo: view.heightAnchor, multiplier: 0.05),
+            nextButton.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.9),
+            nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+}

--- a/roome/roome/Presentation/ViewModel/TermsOfServiceViewModel.swift
+++ b/roome/roome/Presentation/ViewModel/TermsOfServiceViewModel.swift
@@ -1,0 +1,105 @@
+//
+//  TermsOfServiceViewModel.swift
+//  roome
+//
+//  Created by minsong kim on 5/19/24.
+//
+
+import Foundation
+import Combine
+
+
+class TermsOfServiceViewModel {
+    struct ButtonStates {
+        var allAgree: Bool = false
+        var ageAgree: Bool = false
+        var service: Bool = false
+        var personal: Bool = false
+        var advertise: Bool = false
+    }
+    
+    var buttonStates = ButtonStates()
+    
+    struct TermsOfServiceInput {
+        let allAgree: AnyPublisher<Void, Never>
+        let ageAgree: AnyPublisher<Void, Never>
+        let service: AnyPublisher<Void, Never>
+        let personal: AnyPublisher<Void, Never>
+        let advertise: AnyPublisher<Void, Never>
+    }
+    
+    struct TermsOfServiceOutput {
+        let isAllAgreeOn: AnyPublisher<Bool, Never>
+        let isNextButtonOn: AnyPublisher<Bool, Never>
+        let states: AnyPublisher<ButtonStates, Never>
+    }
+    
+    func transform(_ input: TermsOfServiceInput) -> TermsOfServiceOutput {
+        let all = input.allAgree
+            .handleEvents(receiveOutput: { [weak self] _ in
+                guard let self else { return }
+                self.buttonStates.allAgree.toggle()
+                
+                if self.buttonStates.allAgree {
+                    self.buttonStates.ageAgree = true
+                    self.buttonStates.service = true
+                    self.buttonStates.personal = true
+                    self.buttonStates.advertise = true
+                } else {
+                    self.buttonStates.ageAgree = false
+                    self.buttonStates.service = false
+                    self.buttonStates.personal = false
+                    self.buttonStates.advertise = false
+                }
+            }).share()
+        
+        let age = input.ageAgree
+            .handleEvents(receiveOutput: { [weak self] _ in
+                self?.buttonStates.ageAgree.toggle()
+            })
+            .share()
+        
+        let service = input.service
+            .handleEvents(receiveOutput: { [weak self] _ in
+                self?.buttonStates.service.toggle()
+            })
+            .share()
+        
+        let personal = input.personal
+            .handleEvents(receiveOutput: { [weak self] _ in
+                self?.buttonStates.personal.toggle()
+            })
+            .share()
+    
+        let advertise = input.advertise
+            .handleEvents(receiveOutput: { [weak self] _ in
+                self?.buttonStates.advertise.toggle()
+            }).share()
+        
+        let state = Publishers.Merge5(all, age, service, personal, advertise)
+            .compactMap { [weak self] _ in
+                self?.buttonStates
+            }.eraseToAnyPublisher()
+        
+        let nextButton = Publishers.Merge4(all, age, service, personal)
+            .compactMap { [weak self] _ in
+                guard let self else {
+                    return false
+                }
+                
+                return self.buttonStates.ageAgree && self.buttonStates.service && self.buttonStates.personal
+            }.eraseToAnyPublisher()
+        
+        let isAllAgreeOn = Publishers.Merge5(all, age, service, personal, advertise)
+            .compactMap { [weak self] _ in
+                guard let self else {
+                    return false
+                }
+                
+                return self.buttonStates.ageAgree && self.buttonStates.service && self.buttonStates.personal &&
+                    self.buttonStates.advertise
+            }.eraseToAnyPublisher()
+        
+        return TermsOfServiceOutput(isAllAgreeOn: isAllAgreeOn, isNextButtonOn: nextButton, states: state)
+    }
+}


### PR DESCRIPTION
## 🔥 트러블 슈팅
### 1️⃣. Combine 사용한 반응형 버튼
- combine은 button state에 대해 관찰하고 발행하는 publisher가 따로 구현되어 있지 않음. 
- cocoaCombine 참고
```swift
extension UIControl {
    struct EventPublisher: Publisher {
        typealias Output = Void
        typealias Failure = Never

        fileprivate var control: UIControl
        fileprivate var event: Event

        func receive<S: Subscriber>(subscriber: S) where S.Input == Output, S.Failure == Failure {
            let subscription = EventSubscription<S>()
            subscription.target = subscriber

            subscriber.receive(subscription: subscription)

            control.addTarget(
                subscription,
                action: #selector(subscription.trigger),
                for: event
            )
        }
    }
}

private extension UIControl {
    class EventSubscription<Target: Subscriber>: Subscription where Target.Input == Void {

        var target: Target?

        func request( _ demand: Subscribers.Demand) { }

        func cancel() {
            target = nil
        }

        @objc
        func trigger() {
            _ = target?.receive(())
        }
    }
}

extension UIControl {
    func publisher(for event: Event) -> EventPublisher {
        EventPublisher(
            control: self,
            event: event
        )
    }
}

```

### 2️⃣. 커스텀 버튼
- 하나의 뷰에 두개의 버튼이 들어가는 커스텀 버튼 생성. 
- 해당 뷰에서 publisher 발행하여 반환해주는 함수 구현.

## 🆘 연관된 이슈
close #10 