### PR TITLE
[REFACTOR] QA List

### DIFF
--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -134,6 +134,7 @@
 		928474852C0DB4F9002C3B4C /* SizeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928474842C0DB4F9002C3B4C /* SizeButton.swift */; };
 		928474872C0DBDEB002C3B4C /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928474862C0DBDEB002C3B4C /* ProfileViewModel.swift */; };
 		9293DC6D2C12167F00545B57 /* UIFontMetrics+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC6C2C12167F00545B57 /* UIFontMetrics+.swift */; };
+		9293DC702C1F3EA300545B57 /* DIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC6F2C1F3EA300545B57 /* DIManager.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -267,6 +268,7 @@
 		928474842C0DB4F9002C3B4C /* SizeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeButton.swift; sourceTree = "<group>"; };
 		928474862C0DBDEB002C3B4C /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		9293DC6C2C12167F00545B57 /* UIFontMetrics+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFontMetrics+.swift"; sourceTree = "<group>"; };
+		9293DC6F2C1F3EA300545B57 /* DIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIManager.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -297,6 +299,7 @@
 				92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */,
 				92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */,
 				9216955C2BFBBE2F006DC44A /* DIContainer.swift */,
+				9293DC6F2C1F3EA300545B57 /* DIManager.swift */,
 			);
 			path = Application;
 			sourceTree = "<group>";
@@ -950,6 +953,7 @@
 				921695A32BFE773C006DC44A /* DeviceAndLockViewController.swift in Sources */,
 				9293DC6D2C12167F00545B57 /* UIFontMetrics+.swift in Sources */,
 				9271F7CA2C00B70200586AFD /* BackgroundColor.swift in Sources */,
+				9293DC702C1F3EA300545B57 /* DIManager.swift in Sources */,
 				9271F7F92C089D0200586AFD /* ThemeSelectRepository.swift in Sources */,
 				9271F8092C08A2BE00586AFD /* DeviceLockUseCase.swift in Sources */,
 				921695092BF302D2006DC44A /* LoginViewModel.swift in Sources */,

--- a/roome/roome/Application/DIManager.swift
+++ b/roome/roome/Application/DIManager.swift
@@ -1,0 +1,141 @@
+//
+//  DIManager.swift
+//  roome
+//
+//  Created by minsong kim on 6/17/24.
+//
+
+import UIKit
+
+class DIManager {
+    static let shared = DIManager()
+    
+    private init() {}
+    
+    func registerAll() {
+        registerLoginDependency()
+        registerSignUPDependency()
+        registerExtraDependency()
+        registerProfileDependency()
+    }
+    
+    private func registerLoginDependency() {
+        let loginRepository = LoginRepository()
+        let loginUseCase = LoginUseCase(loginRepository: loginRepository)
+        let loginViewModel = LoginViewModel(loginUseCase: loginUseCase)
+        let loginViewController = LoginViewController(viewModel: loginViewModel)
+        DIContainer.shared.register(LoginRepository.self, dependency: loginRepository)
+        DIContainer.shared.register(LoginUseCase.self, dependency: loginUseCase)
+        DIContainer.shared.register(LoginViewModel.self, dependency: loginViewModel)
+        DIContainer.shared.register(LoginViewController.self, dependency: loginViewController)
+    }
+    
+    private func registerSignUPDependency() {
+        let termsAgreeRepository = TermsAgreeRepository()
+        let termsAgreeUseCase = TermsAgreeUseCase(termsAgreeRepository: termsAgreeRepository)
+        let termsAgreeViewModel = TermsAgreeViewModel(termsUseCase: termsAgreeUseCase)
+        let termsAgreeViewController = TermsAgreeViewController(viewModel: termsAgreeViewModel)
+
+        DIContainer.shared.register(TermsAgreeViewModel.self, dependency: termsAgreeViewModel)
+        DIContainer.shared.register(TermsAgreeViewController.self, dependency: termsAgreeViewController)
+
+        let nicknameRepository = NicknameRepository()
+        let nicknameUseCase = NicknameUseCase(nicknameRepository: nicknameRepository)
+        let nicknameViewModel = NicknameViewModel(usecase: nicknameUseCase)
+        let nicknameViewController = NicknameViewController(viewModel: nicknameViewModel)
+        
+        DIContainer.shared.register(NicknameViewController.self, dependency: nicknameViewController)
+    }
+    
+    private func registerProfileDependency() {
+        let welcomeViewModel = WelcomeViewModel()
+        let welcomeSignUPViewController = WelcomeSignUPViewController(viewModel: welcomeViewModel)
+        DIContainer.shared.register(WelcomeViewModel.self, dependency: welcomeViewModel)
+        DIContainer.shared.register(WelcomeSignUPViewController.self, dependency: welcomeSignUPViewController)
+        
+        let roomCountRepository = RoomCountRepository()
+        let roomCountUseCase = RoomCountUseCase(repository: roomCountRepository)
+        let roomCountViewModel = RoomCountViewModel(usecase: roomCountUseCase)
+        let roomCountViewController = RoomCountViewController(viewModel: roomCountViewModel)
+        DIContainer.shared.register(RoomCountRepository.self, dependency: roomCountRepository)
+        DIContainer.shared.register(RoomCountUseCase.self, dependency: roomCountUseCase)
+        DIContainer.shared.register(RoomCountViewModel.self, dependency: roomCountViewModel)
+        DIContainer.shared.register(RoomCountViewController.self, dependency: roomCountViewController)
+        
+        let genreRepository = GenreRepository()
+        let genreUseCase = GenreUseCase(repository: genreRepository)
+        let genreViewModel = GenreViewModel(useCase: genreUseCase)
+        let genreViewController = GenreViewController(viewModel: genreViewModel)
+        DIContainer.shared.register(GenreViewController.self, dependency: genreViewController)
+        
+        let mbtiRepository = MbtiRepository()
+        let mbtiUseCase = MbtiUseCase(repository: mbtiRepository)
+        let mbtiViewModel = MBTIViewModel(useCase: mbtiUseCase)
+        let mbtiViewController = MBTIViewController(viewModel: mbtiViewModel)
+        DIContainer.shared.register(MBTIViewController.self, dependency: mbtiViewController)
+        
+        let strengthRepository = StrengthRepository()
+        let strengthUseCase = StrengthUseCase(repository: strengthRepository)
+        let strengthViewModel = StrengthViewModel(useCase: strengthUseCase)
+        let strengthViewController = StrengthViewController(viewModel: strengthViewModel)
+        DIContainer.shared.register(StrengthViewController.self, dependency: strengthViewController)
+        
+        let themeRepository = ThemeSelectRepository()
+        let themeUseCase = ThemeSelectUseCase(repository: themeRepository)
+        let themeViewModel = ImportantFactorViewModel(useCase: themeUseCase)
+        let themeSelectViewController = ImportantFactorViewController(viewModel: themeViewModel)
+        DIContainer.shared.register(ImportantFactorViewController.self, dependency: themeSelectViewController)
+        
+        let horrorRepository = HorrorThemeRepository()
+        let horrorUseCase = HorrorThemeUseCase(repository: horrorRepository)
+        let horrorViewModel = HorrorPositionViewModel(useCase: horrorUseCase)
+        let horrorPositionViewController = HorrorPositionViewController(viewModel: horrorViewModel)
+        DIContainer.shared.register(HorrorPositionViewController.self, dependency: horrorPositionViewController)
+        
+        let hintRepository = HintRepository()
+        let hintUseCase = HintUseCase(repository: hintRepository)
+        let hintViewModel = HintViewModel(useCase: hintUseCase)
+        let hintViewController = HintViewController(viewModel: hintViewModel)
+        DIContainer.shared.register(HintViewController.self, dependency: hintViewController)
+        
+        let deviceLockRepository = DeviceLockRepository()
+        let deviceLockUseCase = DeviceLockUseCase(repository: deviceLockRepository)
+        let deviceLockViewModel = DeviceAndLockViewModel(useCase: deviceLockUseCase)
+        let deviceAndLockViewController = DeviceAndLockViewController(viewModel: deviceLockViewModel)
+        DIContainer.shared.register(DeviceAndLockViewController.self, dependency: deviceAndLockViewController)
+        
+        let activityRepository = ActivityRepository()
+        let activityUseCase = ActivityUseCase(repository: activityRepository)
+        let activityViewModel = ActivityViewModel(useCase: activityUseCase)
+        let activityViewController = ActivityViewController(viewModel: activityViewModel)
+        DIContainer.shared.register(ActivityViewController.self, dependency: activityViewController)
+        
+        let dislikeRepository = DislikeRepository()
+        let dislikeUseCase = DislikeUseCase(repository: dislikeRepository)
+        let dislikeViewModel = DislikeViewModel(useCase: dislikeUseCase)
+        let dislikeViewController = DislikeViewController(viewModel: dislikeViewModel)
+        DIContainer.shared.register(DislikeViewController.self, dependency: dislikeViewController)
+        
+        let colorRepository = ColorRepository()
+        let colorUseCase = ColorUseCase(repository: colorRepository)
+        let colorViewModel = ColorSelectViewModel(useCase: colorUseCase)
+        let colorSelectViewController = ColorSelectViewController(viewModel: colorViewModel)
+        DIContainer.shared.register(ColorSelectViewController.self, dependency: colorSelectViewController)
+        
+        let profileViewController = ProfileViewController(viewModel: ProfileViewModel())
+        DIContainer.shared.register(ProfileViewController.self, dependency: profileViewController)
+        
+        let signOutViewModel = SignOutViewModel(loginUseCase: DIContainer.shared.resolve(LoginUseCase.self))
+        let signOutViewController = SignOutViewController(viewModel: signOutViewModel)
+        DIContainer.shared.register(SignOutViewController.self, dependency: signOutViewController)
+    }
+    
+    private func registerExtraDependency() {
+        guard let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first else {
+            return
+        }
+        
+        let loadingView = LoadingView(frame: window.frame)
+        DIContainer.shared.register(LoadingView.self, dependency: loadingView)
+    }
+}

--- a/roome/roome/Assets.xcassets/disableColor.colorset/Contents.json
+++ b/roome/roome/Assets.xcassets/disableColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "223",
+          "green" : "223",
+          "red" : "223"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "223",
+          "green" : "223",
+          "red" : "223"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/roome/roome/Assets.xcassets/disableTintColor.colorset/Contents.json
+++ b/roome/roome/Assets.xcassets/disableTintColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "180",
+          "green" : "180",
+          "red" : "180"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "180",
+          "green" : "180",
+          "red" : "180"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/roome/roome/DesignSystem/CustomUI/Button/NextButton.swift
+++ b/roome/roome/DesignSystem/CustomUI/Button/NextButton.swift
@@ -10,13 +10,11 @@ import UIKit
 class NextButton: UIButton {
     override init(frame: CGRect = .zero) {
         super.init(frame: frame)
-        self.tintColor = .white
         self.layer.cornerRadius = 10
         self.setTitle("다음", for: .normal)
         self.titleLabel?.font = .boldTitle3
         self.isEnabled = false
         self.translatesAutoresizingMaskIntoConstraints = false
-        self.backgroundColor = .gray
     }
     
     convenience init(title: String, backgroundColor: UIColor, tintColor: UIColor) {
@@ -26,6 +24,18 @@ class NextButton: UIButton {
         self.backgroundColor = backgroundColor
         self.tintColor = tintColor
         self.setTitleColor(tintColor, for: .normal)
+    }
+    
+    override var isEnabled: Bool {
+        didSet {
+            if isEnabled {
+                self.backgroundColor = .roomeMain
+                self.setTitleColor(.white, for: .normal)
+            } else {
+                self.backgroundColor = .disable
+                self.setTitleColor(.disableTint, for: .normal)
+            }
+        }
     }
 
     required init?(coder: NSCoder) {

--- a/roome/roome/DesignSystem/CustomUI/Button/SizeButton.swift
+++ b/roome/roome/DesignSystem/CustomUI/Button/SizeButton.swift
@@ -29,8 +29,10 @@ class SizeButton: UIButton {
         didSet {
             if isSelected {
                 self.layer.borderColor = UIColor.roomeMain.cgColor
+                self.layer.borderWidth = 2
             } else {
-                self.layer.borderColor = UIColor.gray.cgColor
+                self.layer.borderColor = UIColor.disableTint.cgColor
+                self.layer.borderWidth = 1
             }
         }
     }

--- a/roome/roome/DesignSystem/CustomUI/ProfileStateLineView.swift
+++ b/roome/roome/DesignSystem/CustomUI/ProfileStateLineView.swift
@@ -53,9 +53,9 @@ class ProfileStateLineView: UIView {
         let start = (frame.width / CGFloat(11)) * colorCount
         
         let pattern: [CGFloat] = [bar, space]
-        UIColor.lightGray.set()
+        UIColor.disableTint.set()
         path.move(to: CGPoint(x: start + space, y: 10))
-        path.addLine(to: CGPoint(x: frame.width - 4, y: 10))
+        path.addLine(to: CGPoint(x: frame.width - 2, y: 10))
         path.lineWidth = 2
         path.lineCapStyle = .round
         path.setLineDash(pattern, count: pattern.count, phase: 0)

--- a/roome/roome/DesignSystem/CustomUI/ToastAlertable.swift
+++ b/roome/roome/DesignSystem/CustomUI/ToastAlertable.swift
@@ -15,7 +15,7 @@ extension ToastAlertable {
     func showToast(count: Int) {
         let toastLabel = PaddingLabel(frame: CGRect(
             x: self.nextButton.frame.minX,
-            y: self.nextButton.frame.minY - 25,
+            y: self.nextButton.frame.minY - 60,
             width: self.nextButton.frame.width,
             height: self.nextButton.frame.height
         ))

--- a/roome/roome/Main/Presentation/SignOutViewController.swift
+++ b/roome/roome/Main/Presentation/SignOutViewController.swift
@@ -44,7 +44,8 @@ class SignOutViewController: UIViewController {
                         .changeRootViewController(next, animated: true)
             } receiveValue: { _ in
                     DIContainer.shared.resolveAll()
-                    let next = DIContainer.shared.resolve(SplashView.self)
+                    DIManager.shared.registerAll()
+                    let next = DIContainer.shared.resolve(LoginViewController.self)
                     (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first?.rootViewController?.dismiss(animated: false)
                     (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
                         .changeRootViewController(next, animated: true)

--- a/roome/roome/ProfileCreate/Presentation/ProfileView.swift
+++ b/roome/roome/ProfileCreate/Presentation/ProfileView.swift
@@ -134,8 +134,8 @@ class ProfileView: UIView {
         
         NSLayoutConstraint.activate([
             stackView.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 12),
-            stackView.centerXAnchor.constraint(equalTo: self.centerXAnchor),
-            stackView.widthAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.8),
+            stackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 24),
+            stackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -24),
             stackView.heightAnchor.constraint(equalTo: self.widthAnchor, multiplier: 0.7)
         ])
     }

--- a/roome/roome/ProfileCreate/Presentation/ProfileViewController.swift
+++ b/roome/roome/ProfileCreate/Presentation/ProfileViewController.swift
@@ -45,7 +45,7 @@ class ProfileViewController: UIViewController {
     //Button
     private let squareButton = SizeButton(title: SizeDTO.square.title, isSelected: true)
     private let rectangleButton = SizeButton(title: SizeDTO.rectangle.title, isSelected: false)
-    private let saveButton = NextButton(title: "저장하기", backgroundColor: .roomeMain, tintColor: .white)
+    private let saveButton = NextButton(title: "이미지로 저장하기", backgroundColor: .roomeMain, tintColor: .white)
     private let pageButton = NextButton(title: "프로필 페이지로 이동", backgroundColor: .clear, tintColor: .lightGray)
     
     //Window

--- a/roome/roome/ProfileSelect/Presentation/CustomUI/Cell/ButtonCell.swift
+++ b/roome/roome/ProfileSelect/Presentation/CustomUI/Cell/ButtonCell.swift
@@ -78,6 +78,7 @@ class ButtonCell: UICollectionViewCell {
         descriptionLabel.text = text
         descriptionLabel.numberOfLines = 0
         descriptionLabel.textColor = .gray
+        descriptionLabel.textAlignment = .center
         descriptionLabel.font = .regularBody2
     }
     

--- a/roome/roome/ProfileSelect/Presentation/CustomUI/Cell/ButtonCell.swift
+++ b/roome/roome/ProfileSelect/Presentation/CustomUI/Cell/ButtonCell.swift
@@ -8,6 +8,16 @@
 import UIKit
 
 class ButtonCell: UICollectionViewCell {
+    var isChecked: Bool {
+        didSet {
+            if isChecked {
+                changeLabelColor(title: .disable, description: .disable)
+            } else {
+                changeLabelColor(title: .label, description: .gray)
+            }
+        }
+    }
+    
     private let stackView: UIStackView = {
         let stack = UIStackView()
         stack.translatesAutoresizingMaskIntoConstraints = false
@@ -22,6 +32,7 @@ class ButtonCell: UICollectionViewCell {
     let descriptionLabel = UILabel()
     
     override init(frame: CGRect) {
+        self.isChecked = false
         super.init(frame: frame)
         
         contentView.layer.borderColor = UIColor.disableTint.cgColor
@@ -65,7 +76,13 @@ class ButtonCell: UICollectionViewCell {
     
     func addDescription(_ text: String) {
         descriptionLabel.text = text
+        descriptionLabel.numberOfLines = 0
         descriptionLabel.textColor = .gray
         descriptionLabel.font = .regularBody2
+    }
+    
+    func changeLabelColor(title: UIColor, description: UIColor) {
+        titleLabel.textColor = title
+        descriptionLabel.textColor = description
     }
 }

--- a/roome/roome/ProfileSelect/Presentation/CustomUI/Cell/ButtonCell.swift
+++ b/roome/roome/ProfileSelect/Presentation/CustomUI/Cell/ButtonCell.swift
@@ -24,7 +24,7 @@ class ButtonCell: UICollectionViewCell {
     override init(frame: CGRect) {
         super.init(frame: frame)
         
-        contentView.layer.borderColor = UIColor.gray.cgColor
+        contentView.layer.borderColor = UIColor.disableTint.cgColor
         contentView.layer.borderWidth = 1
         contentView.layer.cornerRadius = 10
         contentView.layer.masksToBounds = true
@@ -50,8 +50,10 @@ class ButtonCell: UICollectionViewCell {
         didSet {
             if isSelected {
                 contentView.layer.borderColor = UIColor.roomeMain.cgColor
+                contentView.layer.borderWidth = 2
             } else {
-                contentView.layer.borderColor = UIColor.lightGray.cgColor
+                contentView.layer.borderColor = UIColor.disableTint.cgColor
+                contentView.layer.borderWidth = 1
             }
         }
     }

--- a/roome/roome/ProfileSelect/Presentation/View/DeviceAndLockViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/DeviceAndLockViewController.swift
@@ -12,8 +12,7 @@ class DeviceAndLockViewController: UIViewController {
     private let titleLabel = TitleLabel(text: "장치와 자물쇠 중\n어떤 것을 더 선호하시나요?")
     lazy var profileCount = ProfileStateLineView(pageNumber: 8, frame: CGRect(x: 20, y: 60, width: view.frame.width * 0.9 - 10, height: view.frame.height))
     private let backButton = BackButton()
-    private lazy var flowLayout = self.createFlowLayout()
-    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout)
+    private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     var viewModel: DeviceAndLockViewModel
     var cancellables = Set<AnyCancellable>()
     
@@ -73,7 +72,7 @@ class DeviceAndLockViewController: UIViewController {
         view.addSubview(collectionView)
         
         NSLayoutConstraint.activate([
-            collectionView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+            collectionView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
             collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             collectionView.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -50)
@@ -95,20 +94,9 @@ class DeviceAndLockViewController: UIViewController {
             titleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
         ])
     }
-    
-    func createFlowLayout() -> UICollectionViewFlowLayout {
-        let layout = UICollectionViewFlowLayout()
-        layout.minimumLineSpacing = 10
-        layout.minimumInteritemSpacing = 10
-        layout.itemSize = CGSize(width: view.frame.width * 0.9, height: 50)
-        layout.sectionInset = UIEdgeInsets(top: 10, left: 24, bottom: 50, right: 24)
-        
-        return layout
-    }
-
 }
 
-extension DeviceAndLockViewController: UICollectionViewDataSource, UICollectionViewDelegate  {
+extension DeviceAndLockViewController: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         UserContainer.shared.defaultProfile?.data.deviceLockPreferences.count ?? 0
     }
@@ -124,7 +112,7 @@ extension DeviceAndLockViewController: UICollectionViewDataSource, UICollectionV
         }
         
         cell.changeTitle(device.title)
-//        cell.addDescription(DeviceLockDTO(rawValue: indexPath.row + 1)!.description)
+        cell.addDescription(device.description)
         
         return cell
     }
@@ -137,4 +125,31 @@ extension DeviceAndLockViewController: UICollectionViewDataSource, UICollectionV
     }
 }
 
+extension DeviceAndLockViewController: UICollectionViewDelegateFlowLayout {
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
+        10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+        10
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+        
+        guard let device = UserContainer.shared.defaultProfile?.data.deviceLockPreferences[indexPath.row] else {
+            return .zero
+        }
+        
+        var height: CGFloat = 50
+        
+        if device.description != "" {
+            height = 80
+        }
+        
+        let width = view.frame.width * 0.9
+        
+        
+        return CGSize(width: width, height: height)
+    }
+}
 

--- a/roome/roome/ProfileSelect/Presentation/View/DislikeViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/DislikeViewController.swift
@@ -58,10 +58,8 @@ class DislikeViewController: UIViewController, ToastAlertable {
             .sink { [weak self] result in
                 if result {
                     self?.nextButton.isEnabled = true
-                    self?.nextButton.backgroundColor = .roomeMain
                 } else {
                     self?.nextButton.isEnabled = false
-                    self?.nextButton.backgroundColor = .gray
                 }
             }.store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/GenreViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/GenreViewController.swift
@@ -59,10 +59,8 @@ class GenreViewController: UIViewController, ToastAlertable {
             .sink { [weak self] result in
                 if result {
                     self?.nextButton.isEnabled = true
-                    self?.nextButton.backgroundColor = .roomeMain
                 } else {
                     self?.nextButton.isEnabled = false
-                    self?.nextButton.backgroundColor = .gray
                 }
             }.store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/ImportantFactorViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/ImportantFactorViewController.swift
@@ -58,10 +58,8 @@ class ImportantFactorViewController: UIViewController, ToastAlertable {
             .sink { [weak self] result in
                 if result {
                     self?.nextButton.isEnabled = true
-                    self?.nextButton.backgroundColor = .roomeMain
                 } else {
                     self?.nextButton.isEnabled = false
-                    self?.nextButton.backgroundColor = .gray
                 }
             }.store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
@@ -72,10 +72,8 @@ class MBTIViewController: UIViewController {
             .sink { [weak self] result in
                 if result {
                     self?.nextButton.isEnabled = true
-                    self?.nextButton.backgroundColor = .roomeMain
                 } else {
                     self?.nextButton.isEnabled = false
-                    self?.nextButton.backgroundColor = .gray
                 }
             }.store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
@@ -19,7 +19,7 @@ class MBTIViewController: UIViewController {
     private let willNotAddButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
-        configuration.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.lightGray).resize(newWidth: 24)
+        configuration.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.gray).resize(newWidth: 24)
         configuration.imagePadding = 8
         configuration.contentInsets = NSDirectionalEdgeInsets(top: 15, leading: 24, bottom: 10, trailing: 20)
         configuration.title = "프로필에 추가하지 않을래요"
@@ -98,10 +98,16 @@ class MBTIViewController: UIViewController {
             .sink { [weak self] result in
                 if result {
                     self?.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.roomeMain).resize(newWidth: 24)
-                    self?.collectionView.allowsSelection = false
+                    _ = self?.collectionView.visibleCells.map { $0.isSelected = false }
+                    _ = self?.collectionView.visibleCells
+                        .compactMap { $0 as? ButtonCell }
+                        .map { $0.isChecked = true }
+                    self?.collectionView.reloadData()
                 } else {
-                    self?.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.lightGray).resize(newWidth: 24)
-                    self?.collectionView.allowsMultipleSelection = true
+                    self?.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.gray).resize(newWidth: 24)
+                    _ = self?.collectionView.visibleCells
+                        .compactMap { $0 as? ButtonCell }
+                        .map { $0.isChecked = false }
                 }
             }.store(in: &cancellables)
         
@@ -199,6 +205,10 @@ extension MBTIViewController: UICollectionViewDataSource, UICollectionViewDelega
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         viewModel.selectCell.send(indexPath)
+        _ = collectionView.visibleCells
+            .compactMap { $0 as? ButtonCell }
+            .map { $0.isChecked = false }
+        self.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.gray).resize(newWidth: 24)
     }
     
     func collectionView(_ collectionView: UICollectionView, didDeselectItemAt indexPath: IndexPath) {

--- a/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
@@ -116,7 +116,6 @@ class RoomCountViewController: UIViewController {
         nextButton.isEnabled = false
         nextButton.backgroundColor = .gray
         numberTextField.delegate = self
-        numberTextField.becomeFirstResponder()
         configureUI()
         configureSizeButtons()
         configureSelectButton()
@@ -190,6 +189,7 @@ class RoomCountViewController: UIViewController {
                     self?.rangeButton.isSelected.toggle()
                     self?.textFieldButton.isSelected.toggle()
                     self?.selectButton.layoutIfNeeded()
+                    self?.numberTextField.becomeFirstResponder()
                 }
             }.store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
@@ -23,8 +23,8 @@ class RoomCountViewController: UIViewController {
         configuration.baseForegroundColor = .label
         configuration.title = "선택"
         configuration.cornerStyle = .large
-        configuration.background.strokeColor = .systemGray4
-        configuration.background.strokeWidth = 2
+        configuration.background.strokeColor = .disableTint
+        configuration.background.strokeWidth = 1
         
         let button = UIButton(configuration: configuration)
         button.titleLabel?.font = .boldLabel

--- a/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
@@ -119,8 +119,6 @@ class RoomCountViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = .systemBackground
-        nextButton.isEnabled = false
-        nextButton.backgroundColor = .gray
         numberTextField.delegate = self
         configureUI()
         configureSizeButtons()
@@ -152,10 +150,8 @@ class RoomCountViewController: UIViewController {
             .sink(receiveValue: { [weak self] isNextButtonOn in
                 if isNextButtonOn {
                     self?.nextButton.isEnabled = true
-                    self?.nextButton.backgroundColor = .roomeMain
                 } else {
                     self?.nextButton.isEnabled = false
-                    self?.nextButton.backgroundColor = .gray
                 }
             }).store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
@@ -21,9 +21,6 @@ class RoomCountViewController: UIViewController {
     private lazy var selectButton: UIButton = {
         var configuration = UIButton.Configuration.plain()
         configuration.baseForegroundColor = .label
-        configuration.image = UIImage(systemName: "arrowtriangle.down.fill")?.changeImageColor(.lightGray).resize(newWidth: 12)
-        configuration.imageReservation = 20
-        configuration.imagePlacement = .trailing
         configuration.title = "선택"
         configuration.cornerStyle = .large
         configuration.background.strokeColor = .systemGray4
@@ -35,6 +32,15 @@ class RoomCountViewController: UIViewController {
         button.contentHorizontalAlignment = .leading
         
         return button
+    }()
+    let dropdownImage: UIImageView = {
+        let image = UIImage(systemName: "arrowtriangle.down.fill")?.changeImageColor(.lightGray).resize(newWidth: 10)
+        let view = UIImageView(image: image)
+        view.contentMode = .scaleAspectFit
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        
+        return view
     }()
     let tableView: UITableView = {
         let view = UITableView()
@@ -245,12 +251,17 @@ class RoomCountViewController: UIViewController {
     
     private func configureSelectButton() {
         view.addSubview(selectButton)
+        view.addSubview(dropdownImage)
         
         NSLayoutConstraint.activate([
             selectButton.topAnchor.constraint(equalTo: rangeButton.bottomAnchor, constant: 16),
             selectButton.leadingAnchor.constraint(equalTo: rangeButton.leadingAnchor),
             selectButton.trailingAnchor.constraint(equalTo: textFieldButton.trailingAnchor),
-            selectButton.heightAnchor.constraint(equalTo: rangeButton.heightAnchor)
+            selectButton.heightAnchor.constraint(equalTo: rangeButton.heightAnchor),
+            
+            dropdownImage.trailingAnchor.constraint(equalTo: selectButton.trailingAnchor, constant: -16),
+            dropdownImage.topAnchor.constraint(equalTo: selectButton.topAnchor),
+            dropdownImage.bottomAnchor.constraint(equalTo: selectButton.bottomAnchor)
         ])
     }
     

--- a/roome/roome/SplashView.swift
+++ b/roome/roome/SplashView.swift
@@ -26,15 +26,12 @@ class SplashView: UIViewController {
             logoView.centerYAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerYAnchor)
         ])
     }
-
+    
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         if KeyChain.read(key: .hasToken) == "true" {
             Task { @MainActor in
-                registerLoginDependency()
-                registerSignUPDependency()
-                registerExtraDependency()
-                registerProfileDependency()
+                DIManager.shared.registerAll()
                 do {
                     try await UserContainer.shared.updateUserInformation()
                     setIsLogin()
@@ -43,10 +40,7 @@ class SplashView: UIViewController {
                 }
             }
         } else {
-            registerLoginDependency()
-            registerSignUPDependency()
-            registerExtraDependency()
-            registerProfileDependency()
+            DIManager.shared.registerAll()
             setIsLogin()
         }
     }
@@ -83,128 +77,5 @@ class SplashView: UIViewController {
         
         (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
             .changeRootViewController(viewController, animated: true)
-    }
-    
-    func registerLoginDependency() {
-        let loginRepository = LoginRepository()
-        let loginUseCase = LoginUseCase(loginRepository: loginRepository)
-        let loginViewModel = LoginViewModel(loginUseCase: loginUseCase)
-        let loginViewController = LoginViewController(viewModel: loginViewModel)
-        DIContainer.shared.register(LoginRepository.self, dependency: loginRepository)
-        DIContainer.shared.register(LoginUseCase.self, dependency: loginUseCase)
-        DIContainer.shared.register(LoginViewModel.self, dependency: loginViewModel)
-        DIContainer.shared.register(LoginViewController.self, dependency: loginViewController)
-    }
-    
-    func registerSignUPDependency() {
-        let termsAgreeRepository = TermsAgreeRepository()
-        let termsAgreeUseCase = TermsAgreeUseCase(termsAgreeRepository: termsAgreeRepository)
-        let termsAgreeViewModel = TermsAgreeViewModel(termsUseCase: termsAgreeUseCase)
-        let termsAgreeViewController = TermsAgreeViewController(viewModel: termsAgreeViewModel)
-        DIContainer.shared.register(TermsAgreeRepository.self, dependency: termsAgreeRepository)
-        DIContainer.shared.register(TermsAgreeUseCase.self, dependency: termsAgreeUseCase)
-        DIContainer.shared.register(TermsAgreeViewModel.self, dependency: termsAgreeViewModel)
-        DIContainer.shared.register(TermsAgreeViewController.self, dependency: termsAgreeViewController)
-
-        let nicknameRepository = NicknameRepository()
-        let nicknameUseCase = NicknameUseCase(nicknameRepository: nicknameRepository)
-        let nicknameViewModel = NicknameViewModel(usecase: nicknameUseCase)
-        let nicknameViewController = NicknameViewController(viewModel: nicknameViewModel)
-        DIContainer.shared.register(NicknameRepository.self, dependency: nicknameRepository)
-        DIContainer.shared.register(NicknameUseCase.self, dependency: nicknameUseCase)
-        DIContainer.shared.register(NicknameViewModel.self, dependency: nicknameViewModel)
-        DIContainer.shared.register(NicknameViewController.self, dependency: nicknameViewController)
-    }
-    
-    func registerProfileDependency() {
-        let welcomeViewModel = WelcomeViewModel()
-        let welcomeSignUPViewController = WelcomeSignUPViewController(viewModel: welcomeViewModel)
-        DIContainer.shared.register(WelcomeViewModel.self, dependency: welcomeViewModel)
-        DIContainer.shared.register(WelcomeSignUPViewController.self, dependency: welcomeSignUPViewController)
-        
-        let roomCountRepository = RoomCountRepository()
-        let roomCountUseCase = RoomCountUseCase(repository: roomCountRepository)
-        let roomCountViewModel = RoomCountViewModel(usecase: roomCountUseCase)
-        let roomCountViewController = RoomCountViewController(viewModel: roomCountViewModel)
-        DIContainer.shared.register(RoomCountRepository.self, dependency: roomCountRepository)
-        DIContainer.shared.register(RoomCountUseCase.self, dependency: roomCountUseCase)
-        DIContainer.shared.register(RoomCountViewModel.self, dependency: roomCountViewModel)
-        DIContainer.shared.register(RoomCountViewController.self, dependency: roomCountViewController)
-        
-        let genreRepository = GenreRepository()
-        let genreUseCase = GenreUseCase(repository: genreRepository)
-        let genreViewModel = GenreViewModel(useCase: genreUseCase)
-        let genreViewController = GenreViewController(viewModel: genreViewModel)
-        DIContainer.shared.register(GenreViewController.self, dependency: genreViewController)
-        
-        let mbtiRepository = MbtiRepository()
-        let mbtiUseCase = MbtiUseCase(repository: mbtiRepository)
-        let mbtiViewModel = MBTIViewModel(useCase: mbtiUseCase)
-        let mbtiViewController = MBTIViewController(viewModel: mbtiViewModel)
-        DIContainer.shared.register(MBTIViewController.self, dependency: mbtiViewController)
-        
-        let strengthRepository = StrengthRepository()
-        let strengthUseCase = StrengthUseCase(repository: strengthRepository)
-        let strengthViewModel = StrengthViewModel(useCase: strengthUseCase)
-        let strengthViewController = StrengthViewController(viewModel: strengthViewModel)
-        DIContainer.shared.register(StrengthViewController.self, dependency: strengthViewController)
-        
-        let themeRepository = ThemeSelectRepository()
-        let themeUseCase = ThemeSelectUseCase(repository: themeRepository)
-        let themeViewModel = ImportantFactorViewModel(useCase: themeUseCase)
-        let themeSelectViewController = ImportantFactorViewController(viewModel: themeViewModel)
-        DIContainer.shared.register(ImportantFactorViewController.self, dependency: themeSelectViewController)
-        
-        let horrorRepository = HorrorThemeRepository()
-        let horrorUseCase = HorrorThemeUseCase(repository: horrorRepository)
-        let horrorViewModel = HorrorPositionViewModel(useCase: horrorUseCase)
-        let horrorPositionViewController = HorrorPositionViewController(viewModel: horrorViewModel)
-        DIContainer.shared.register(HorrorPositionViewController.self, dependency: horrorPositionViewController)
-        
-        let hintRepository = HintRepository()
-        let hintUseCase = HintUseCase(repository: hintRepository)
-        let hintViewModel = HintViewModel(useCase: hintUseCase)
-        let hintViewController = HintViewController(viewModel: hintViewModel)
-        DIContainer.shared.register(HintViewController.self, dependency: hintViewController)
-        
-        let deviceLockRepository = DeviceLockRepository()
-        let deviceLockUseCase = DeviceLockUseCase(repository: deviceLockRepository)
-        let deviceLockViewModel = DeviceAndLockViewModel(useCase: deviceLockUseCase)
-        let deviceAndLockViewController = DeviceAndLockViewController(viewModel: deviceLockViewModel)
-        DIContainer.shared.register(DeviceAndLockViewController.self, dependency: deviceAndLockViewController)
-        
-        let activityRepository = ActivityRepository()
-        let activityUseCase = ActivityUseCase(repository: activityRepository)
-        let activityViewModel = ActivityViewModel(useCase: activityUseCase)
-        let activityViewController = ActivityViewController(viewModel: activityViewModel)
-        DIContainer.shared.register(ActivityViewController.self, dependency: activityViewController)
-        
-        let dislikeRepository = DislikeRepository()
-        let dislikeUseCase = DislikeUseCase(repository: dislikeRepository)
-        let dislikeViewModel = DislikeViewModel(useCase: dislikeUseCase)
-        let dislikeViewController = DislikeViewController(viewModel: dislikeViewModel)
-        DIContainer.shared.register(DislikeViewController.self, dependency: dislikeViewController)
-        
-        let colorRepository = ColorRepository()
-        let colorUseCase = ColorUseCase(repository: colorRepository)
-        let colorViewModel = ColorSelectViewModel(useCase: colorUseCase)
-        let colorSelectViewController = ColorSelectViewController(viewModel: colorViewModel)
-        DIContainer.shared.register(ColorSelectViewController.self, dependency: colorSelectViewController)
-        
-        let profileViewController = ProfileViewController(viewModel: ProfileViewModel())
-        DIContainer.shared.register(ProfileViewController.self, dependency: profileViewController)
-        
-        let signOutViewModel = SignOutViewModel(loginUseCase: DIContainer.shared.resolve(LoginUseCase.self))
-        let signOutViewController = SignOutViewController(viewModel: signOutViewModel)
-        DIContainer.shared.register(SignOutViewController.self, dependency: signOutViewController)
-    }
-    
-    func registerExtraDependency() {
-        guard let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first else {
-            return
-        }
-        
-        let loadingView = LoadingView(frame: window.frame)
-        DIContainer.shared.register(LoadingView.self, dependency: loadingView)
     }
 }


### PR DESCRIPTION
## 🔥 트러블 슈팅
### 1️⃣. 탈퇴 후 처음 로그인 페이지로 이동
탈퇴하기를 누른 후 다시 로그인 페이지로 이동할 때 DIContainer에 이미 ViewController들이 저장되어 있어서 이전의 유저 정보가 남아있게 되는 문제가 있었다. DIContainer의 모든 정보를 삭제하고 다시 splashView를 잠시 불러서 새롭게 구현체들을 생성해 DIContainer에 저장하도록 수정했다. 

동주 오빠의 리뷰에 따라 SplashView를 다시 띄우는 것은 어색한 것 같아 객체들을 새로 생성하여 DIContainer에 등록하는 DIManager라는 객체를 만들었다. SplashView에서도 이 DIManager를 사용하여 생성하여 등록.
=> https://github.com/Prography-RoomE/roome_ios/pull/37/commits/e61b47ffb8a9a01997955b83ca1f8ce9e18b1748
