### PR TITLE
[FEAT] 약관 동의 상세 페이지 구현

### DIFF
--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -135,6 +135,7 @@
 		928474872C0DBDEB002C3B4C /* ProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928474862C0DBDEB002C3B4C /* ProfileViewModel.swift */; };
 		9293DC6D2C12167F00545B57 /* UIFontMetrics+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC6C2C12167F00545B57 /* UIFontMetrics+.swift */; };
 		9293DC702C1F3EA300545B57 /* DIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC6F2C1F3EA300545B57 /* DIManager.swift */; };
+		9293DC722C200A8D00545B57 /* TermsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC712C200A8D00545B57 /* TermsDetailViewController.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -269,6 +270,7 @@
 		928474862C0DBDEB002C3B4C /* ProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileViewModel.swift; sourceTree = "<group>"; };
 		9293DC6C2C12167F00545B57 /* UIFontMetrics+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFontMetrics+.swift"; sourceTree = "<group>"; };
 		9293DC6F2C1F3EA300545B57 /* DIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIManager.swift; sourceTree = "<group>"; };
+		9293DC712C200A8D00545B57 /* TermsDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsDetailViewController.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 			isa = PBXGroup;
 			children = (
 				921695402BF9008A006DC44A /* TermsAgreeViewController.swift */,
+				9293DC712C200A8D00545B57 /* TermsDetailViewController.swift */,
 				921695332BF765F2006DC44A /* NicknameViewController.swift */,
 			);
 			path = View;
@@ -1007,6 +1010,7 @@
 				921695072BF26F23006DC44A /* APIConstants.swift in Sources */,
 				9271F8072C08A29900586AFD /* DeviceLockRepositoryType.swift in Sources */,
 				9271F81B2C08D1BE00586AFD /* ColorUseCase.swift in Sources */,
+				9293DC722C200A8D00545B57 /* TermsDetailViewController.swift in Sources */,
 				9271F7A82C00A8E100586AFD /* ColorSelectViewController.swift in Sources */,
 				9271F7902BFF8FA800586AFD /* MBTIViewModel.swift in Sources */,
 				9271F7A02C00A53100586AFD /* HintViewModel.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		9293DC6D2C12167F00545B57 /* UIFontMetrics+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC6C2C12167F00545B57 /* UIFontMetrics+.swift */; };
 		9293DC702C1F3EA300545B57 /* DIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC6F2C1F3EA300545B57 /* DIManager.swift */; };
 		9293DC722C200A8D00545B57 /* TermsDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC712C200A8D00545B57 /* TermsDetailViewController.swift */; };
+		9293DC782C209C4800545B57 /* TermsDetailStates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DC772C209C4800545B57 /* TermsDetailStates.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -271,6 +272,7 @@
 		9293DC6C2C12167F00545B57 /* UIFontMetrics+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFontMetrics+.swift"; sourceTree = "<group>"; };
 		9293DC6F2C1F3EA300545B57 /* DIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DIManager.swift; sourceTree = "<group>"; };
 		9293DC712C200A8D00545B57 /* TermsDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsDetailViewController.swift; sourceTree = "<group>"; };
+		9293DC772C209C4800545B57 /* TermsDetailStates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsDetailStates.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -509,6 +511,7 @@
 		9271F7AE2C00AC6300586AFD /* Data */ = {
 			isa = PBXGroup;
 			children = (
+				9293DC772C209C4800545B57 /* TermsDetailStates.swift */,
 				921695642BFC67D0006DC44A /* TermsAgreeRepository.swift */,
 				9216956A2BFC8891006DC44A /* NicknameRepository.swift */,
 			);
@@ -968,6 +971,7 @@
 				9271F81F2C08D5E400586AFD /* StateDTO.swift in Sources */,
 				9271F7C82C00B6D200586AFD /* UIColor+.swift in Sources */,
 				921695922BFE15DB006DC44A /* RoomCountRepository.swift in Sources */,
+				9293DC782C209C4800545B57 /* TermsDetailStates.swift in Sources */,
 				921695152BF35377006DC44A /* LoginRepository.swift in Sources */,
 				9271F8172C08A58000586AFD /* DislikeRepository.swift in Sources */,
 				921695342BF765F2006DC44A /* NicknameViewController.swift in Sources */,

--- a/roome/roome/Application/DIContainer.swift
+++ b/roome/roome/Application/DIContainer.swift
@@ -19,9 +19,21 @@ class DIContainer {
         dependencies[key] = dependency
     }
     
+    func registerDetail(key: String, dependency: Any) {
+        dependencies[key] = dependency
+    }
+    
     func resolve<T>(_ type: T.Type) -> T {
         let key = String(describing: type)
         
+        guard let value = dependencies[key] as? T else {
+            fatalError()
+        }
+        
+        return value
+    }
+    
+    func resolveDetail<T>(_ type: T.Type, key: String) -> T {
         guard let value = dependencies[key] as? T else {
             fatalError()
         }

--- a/roome/roome/Application/DIContainer.swift
+++ b/roome/roome/Application/DIContainer.swift
@@ -19,21 +19,9 @@ class DIContainer {
         dependencies[key] = dependency
     }
     
-    func registerDetail(key: String, dependency: Any) {
-        dependencies[key] = dependency
-    }
-    
     func resolve<T>(_ type: T.Type) -> T {
         let key = String(describing: type)
         
-        guard let value = dependencies[key] as? T else {
-            fatalError()
-        }
-        
-        return value
-    }
-    
-    func resolveDetail<T>(_ type: T.Type, key: String) -> T {
         guard let value = dependencies[key] as? T else {
             fatalError()
         }

--- a/roome/roome/Application/DIManager.swift
+++ b/roome/roome/Application/DIManager.swift
@@ -36,15 +36,11 @@ class DIManager {
         let termsAgreeViewModel = TermsAgreeViewModel(termsUseCase: termsAgreeUseCase)
         let termsAgreeViewController = TermsAgreeViewController(viewModel: termsAgreeViewModel)
         
-        let termsServiceDetailViewController = TermsDetailViewController(terms: .service, viewModel: termsAgreeViewModel)
-        let termsPersonalDetailViewController = TermsDetailViewController(terms: .personal, viewModel: termsAgreeViewModel)
-        let termsAdvertiseDetailViewController = TermsDetailViewController(terms: .advertise, viewModel: termsAgreeViewModel)
+        let termsDetailViewController = TermsDetailViewController(viewModel: termsAgreeViewModel)
 
         DIContainer.shared.register(TermsAgreeViewModel.self, dependency: termsAgreeViewModel)
         DIContainer.shared.register(TermsAgreeViewController.self, dependency: termsAgreeViewController)
-        DIContainer.shared.registerDetail(key: "termsServiceDetailViewController", dependency: termsServiceDetailViewController)
-        DIContainer.shared.registerDetail(key: "termsPersonalDetailViewController", dependency: termsPersonalDetailViewController)
-        DIContainer.shared.registerDetail(key: "termsAdvertiseDetailViewController", dependency: termsAdvertiseDetailViewController)
+        DIContainer.shared.register(TermsDetailViewController.self, dependency: termsDetailViewController)
 
         let nicknameRepository = NicknameRepository()
         let nicknameUseCase = NicknameUseCase(nicknameRepository: nicknameRepository)

--- a/roome/roome/Application/DIManager.swift
+++ b/roome/roome/Application/DIManager.swift
@@ -35,9 +35,16 @@ class DIManager {
         let termsAgreeUseCase = TermsAgreeUseCase(termsAgreeRepository: termsAgreeRepository)
         let termsAgreeViewModel = TermsAgreeViewModel(termsUseCase: termsAgreeUseCase)
         let termsAgreeViewController = TermsAgreeViewController(viewModel: termsAgreeViewModel)
+        
+        let termsServiceDetailViewController = TermsDetailViewController(terms: .service, viewModel: termsAgreeViewModel)
+        let termsPersonalDetailViewController = TermsDetailViewController(terms: .personal, viewModel: termsAgreeViewModel)
+        let termsAdvertiseDetailViewController = TermsDetailViewController(terms: .advertise, viewModel: termsAgreeViewModel)
 
         DIContainer.shared.register(TermsAgreeViewModel.self, dependency: termsAgreeViewModel)
         DIContainer.shared.register(TermsAgreeViewController.self, dependency: termsAgreeViewController)
+        DIContainer.shared.registerDetail(key: "termsServiceDetailViewController", dependency: termsServiceDetailViewController)
+        DIContainer.shared.registerDetail(key: "termsPersonalDetailViewController", dependency: termsPersonalDetailViewController)
+        DIContainer.shared.registerDetail(key: "termsAdvertiseDetailViewController", dependency: termsAdvertiseDetailViewController)
 
         let nicknameRepository = NicknameRepository()
         let nicknameUseCase = NicknameUseCase(nicknameRepository: nicknameRepository)

--- a/roome/roome/DesignSystem/CustomUI/Button/LabelButton.swift
+++ b/roome/roome/DesignSystem/CustomUI/Button/LabelButton.swift
@@ -49,8 +49,11 @@ class LabelButton: UIView {
     }
     
     func tappedMainButtonPublisher() -> AnyPublisher<Void, Never> {
-        mainButton.publisher(for: .touchUpInside)
-            .eraseToAnyPublisher()
+        mainButton.publisher(for: .touchUpInside).eraseToAnyPublisher()
+    }
+    
+    func tappedDetailButtonPublisher() -> AnyPublisher<Void, Never> {
+        detailButton.publisher(for: .touchUpInside).eraseToAnyPublisher()
     }
     
     func setMain(config: UIButton.Configuration) {

--- a/roome/roome/SignUp/Data/TermsDetailStates.swift
+++ b/roome/roome/SignUp/Data/TermsDetailStates.swift
@@ -1,0 +1,36 @@
+//
+//  TermsDetailStates.swift
+//  roome
+//
+//  Created by minsong kim on 6/18/24.
+//
+
+import Foundation
+
+enum TermsDetailStates {
+    case service
+    case personal
+    case advertise
+    
+    var title: String {
+        switch self {
+        case .service:
+            "서비스 이용약관"
+        case .personal:
+            "개인정보처리방침"
+        case .advertise:
+            "광고성 정보 수신 및 마케팅 활용"
+        }
+    }
+    
+    var link: String  {
+        switch self {
+        case .service:
+            "https://marchens.notion.site/9210c54b3ec34a799a6d605f0f605698?pvs=4"
+        case .personal:
+            "https://marchens.notion.site/cb968cba569a404dadc50d5a3e6c79e7?pvs=4"
+        case .advertise:
+            "https://marchens.notion.site/00aaa66a3df4490f8d1cc519f357077b?pvs=4"
+        }
+    }
+}

--- a/roome/roome/SignUp/Presentation/View/TermsAgreeViewController.swift
+++ b/roome/roome/SignUp/Presentation/View/TermsAgreeViewController.swift
@@ -129,6 +129,7 @@ class TermsAgreeViewController: UIViewController {
         configureStackView()
         configureNextButton()
         bind()
+        bindDetailView()
     }
     
     func bind() {
@@ -173,10 +174,8 @@ class TermsAgreeViewController: UIViewController {
             .sink { [weak self] isEnable in
                 if isEnable {
                     self?.nextButton.isEnabled = true
-                    self?.nextButton.backgroundColor = .roomeMain
                 } else {
                     self?.nextButton.isEnabled = false
-                    self?.nextButton.backgroundColor = .gray
                 }
             }.store(in: &cancellable)
         
@@ -210,6 +209,29 @@ class TermsAgreeViewController: UIViewController {
                 self?.navigationController?.popViewController(animated: true)
             }
             .store(in: &cancellable)
+    }
+    
+    func bindDetailView() {
+        serviceAgreeButton.tappedDetailButtonPublisher()
+            .sink { [weak self] _ in
+                let detailView = DIContainer.shared.resolveDetail(TermsDetailViewController.self, key: "termsServiceDetailViewController")
+                detailView.modalPresentationStyle = .fullScreen
+                self?.view.window?.rootViewController?.present(detailView, animated: true)
+            }.store(in: &cancellable)
+        
+        personalInformationAgreeButton.tappedDetailButtonPublisher()
+            .sink { [weak self] _ in
+                let detailView = DIContainer.shared.resolveDetail(TermsDetailViewController.self, key: "termsPersonalDetailViewController")
+                detailView.modalPresentationStyle = .fullScreen
+                self?.view.window?.rootViewController?.present(detailView, animated: true)
+            }.store(in: &cancellable)
+        
+        advertiseAgreeButton.tappedDetailButtonPublisher()
+            .sink { [weak self] _ in
+                let detailView = DIContainer.shared.resolveDetail(TermsDetailViewController.self, key: "termsAdvertiseDetailViewController")
+                detailView.modalPresentationStyle = .fullScreen
+                self?.view.window?.rootViewController?.present(detailView, animated: true)
+            }.store(in: &cancellable)
     }
     
     private func configureStackView() {

--- a/roome/roome/SignUp/Presentation/View/TermsAgreeViewController.swift
+++ b/roome/roome/SignUp/Presentation/View/TermsAgreeViewController.swift
@@ -212,23 +212,29 @@ class TermsAgreeViewController: UIViewController {
     }
     
     func bindDetailView() {
-        serviceAgreeButton.tappedDetailButtonPublisher()
+        let service = serviceAgreeButton.tappedDetailButtonPublisher()
+        let personal = personalInformationAgreeButton.tappedDetailButtonPublisher()
+        let advertise = advertiseAgreeButton.tappedDetailButtonPublisher()
+        
+        let output = viewModel.transformDetail(TermsAgreeViewModel.DetailInput(service: service, personal: personal, advertise: advertise))
+        
+        output.handleService
             .sink { [weak self] _ in
-                let detailView = DIContainer.shared.resolveDetail(TermsDetailViewController.self, key: "termsServiceDetailViewController")
+                let detailView = DIContainer.shared.resolve(TermsDetailViewController.self)
                 detailView.modalPresentationStyle = .fullScreen
                 self?.view.window?.rootViewController?.present(detailView, animated: true)
             }.store(in: &cancellable)
         
-        personalInformationAgreeButton.tappedDetailButtonPublisher()
+        output.handlePersonal
             .sink { [weak self] _ in
-                let detailView = DIContainer.shared.resolveDetail(TermsDetailViewController.self, key: "termsPersonalDetailViewController")
+                let detailView = DIContainer.shared.resolve(TermsDetailViewController.self)
                 detailView.modalPresentationStyle = .fullScreen
                 self?.view.window?.rootViewController?.present(detailView, animated: true)
             }.store(in: &cancellable)
         
-        advertiseAgreeButton.tappedDetailButtonPublisher()
+        output.handleAdvertise
             .sink { [weak self] _ in
-                let detailView = DIContainer.shared.resolveDetail(TermsDetailViewController.self, key: "termsAdvertiseDetailViewController")
+                let detailView = DIContainer.shared.resolve(TermsDetailViewController.self)
                 detailView.modalPresentationStyle = .fullScreen
                 self?.view.window?.rootViewController?.present(detailView, animated: true)
             }.store(in: &cancellable)

--- a/roome/roome/SignUp/Presentation/View/TermsDetailViewController.swift
+++ b/roome/roome/SignUp/Presentation/View/TermsDetailViewController.swift
@@ -1,0 +1,121 @@
+//
+//  TermsDetailViewController.swift
+//  roome
+//
+//  Created by minsong kim on 6/17/24.
+//
+
+import UIKit
+import WebKit
+
+class TermsDetailViewController: UIViewController {
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .boldTitle3
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let closeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "xmark")?.changeImageColor(.label).resize(newWidth: 16)
+        
+        let button = UIButton(configuration: configuration)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let webView: WKWebView = {
+        let configuration = WKWebViewConfiguration()
+        let view = WKWebView(frame: .zero, configuration: configuration)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    let nextButton = NextButton(title: "동의", backgroundColor: .roomeMain, tintColor: .white)
+    
+    init(text: String) {
+        titleLabel.text = text
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureTitleLabel()
+        configureCloseButton()
+        configureNextButton()
+        configureWebView()
+        loadWebView()
+    }
+    
+    private func configureTitleLabel() {
+        view.addSubview(titleLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            titleLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            titleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            titleLabel.heightAnchor.constraint(equalToConstant: 60)
+        ])
+    }
+    
+    private func configureCloseButton() {
+        view.addSubview(closeButton)
+        
+        NSLayoutConstraint.activate([
+            closeButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            closeButton.widthAnchor.constraint(equalToConstant: 24),
+            closeButton.heightAnchor.constraint(equalToConstant: 24),
+            closeButton.centerYAnchor.constraint(equalTo: titleLabel.centerYAnchor)
+        ])
+    }
+    
+    private func configureNextButton() {
+        view.addSubview(nextButton)
+        
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            nextButton.heightAnchor.constraint(equalToConstant: 50),
+            nextButton.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.9),
+            nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+    
+    private func configureWebView() {
+        view.addSubview(webView)
+        
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            webView.bottomAnchor.constraint(equalTo: nextButton.topAnchor, constant: -8)
+        ])
+    }
+    
+    private func loadWebView() {
+        //웹 링크 띄우기
+        guard let url = URL(string: "https://www.notion.so/ROOME-ef60fcf881da4745b4858357fa48b6be") else {
+            return
+        }
+        let request = URLRequest(url: url)
+        
+        webView.load(request)
+        
+        //html 띄우기
+//        let myURL = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "website")!
+//        webView.loadFileURL(myURL, allowingReadAccessTo: myURL)
+    }
+}
+
+#Preview {
+    let vc = TermsDetailViewController(text: "개인 정보 처리 방침")
+    
+    return vc
+}

--- a/roome/roome/SignUp/Presentation/View/TermsDetailViewController.swift
+++ b/roome/roome/SignUp/Presentation/View/TermsDetailViewController.swift
@@ -10,11 +10,9 @@ import WebKit
 import Combine
 
 class TermsDetailViewController: UIViewController {
-    private var termsState: TermsDetailStates
     private lazy var titleLabel: UILabel = {
         let label = UILabel()
         label.font = .boldTitle3
-        label.text = termsState.title
         label.translatesAutoresizingMaskIntoConstraints = false
         
         return label
@@ -42,8 +40,7 @@ class TermsDetailViewController: UIViewController {
     let viewModel: TermsAgreeViewModel
     var cancellable = Set<AnyCancellable>()
     
-    init(terms: TermsDetailStates, viewModel: TermsAgreeViewModel) {
-        self.termsState = terms
+    init(viewModel: TermsAgreeViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
     }
@@ -59,8 +56,13 @@ class TermsDetailViewController: UIViewController {
         configureCloseButton()
         configureNextButton()
         configureWebView()
-        loadWebView()
         bind()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        titleLabel.text = viewModel.detailState?.title
+        loadWebView()
     }
     
     func bind() {
@@ -73,7 +75,7 @@ class TermsDetailViewController: UIViewController {
         agreeButton.publisher(for: .touchUpInside)
             .eraseToAnyPublisher()
             .sink { [weak self] _ in
-                self?.viewModel.handleDetail.send(self?.termsState ?? .personal)
+                self?.viewModel.handleDetail.send()
                 self?.dismiss(animated: true)
             }
             .store(in: &cancellable)
@@ -129,16 +131,13 @@ class TermsDetailViewController: UIViewController {
     
     private func loadWebView() {
         //웹 링크 띄우기
-        guard let url = URL(string: termsState.link) else {
+        guard let link = viewModel.detailState?.link,
+              let url = URL(string: link) else {
             return
         }
         let request = URLRequest(url: url)
         
         webView.load(request)
-        
-        //html 띄우기
-//        let myURL = Bundle.main.url(forResource: "index", withExtension: "html", subdirectory: "website")!
-//        webView.loadFileURL(myURL, allowingReadAccessTo: myURL)
     }
 }
 

--- a/roome/roome/SignUp/Presentation/ViewModel/TermsAgreeViewModel.swift
+++ b/roome/roome/SignUp/Presentation/ViewModel/TermsAgreeViewModel.swift
@@ -39,8 +39,21 @@ class TermsAgreeViewModel {
         let goToNext: AnyPublisher<Void, Error>
         let handleBackButton: AnyPublisher<Void, Never>
     }
+    
+    struct DetailInput {
+        let service: AnyPublisher<Void, Never>
+        let personal: AnyPublisher<Void, Never>
+        let advertise: AnyPublisher<Void, Never>
+    }
+    
+    struct DetailOutput {
+        let handleService: AnyPublisher<Void, Never>
+        let handlePersonal: AnyPublisher<Void, Never>
+        let handleAdvertise: AnyPublisher<Void, Never>
+    }
 
-    let handleDetail = PassthroughSubject<TermsDetailStates, Never>()
+    var detailState: TermsDetailStates?
+    let handleDetail = PassthroughSubject<Void, Never>()
     
     init(termsUseCase: TermsAgreeUseCase?) {
         self.termsUseCase = termsUseCase
@@ -78,8 +91,8 @@ class TermsAgreeViewModel {
             .share()
         
         let detailService = handleDetail
-            .map { state in
-                state == .service
+            .map { [weak self] _ in
+                self?.detailState == .service
             }
             .compactMap { [weak self] state in
                 if state {
@@ -97,8 +110,8 @@ class TermsAgreeViewModel {
             .share()
         
         let detailPersonal = handleDetail
-            .map { state in
-                state == .personal
+            .map { [weak self] in
+                self?.detailState == .personal
             }
             .compactMap { [weak self] state in
                 if state {
@@ -115,8 +128,8 @@ class TermsAgreeViewModel {
             }).share()
         
         let detailAdvertise = handleDetail
-            .map { state in
-                state == .advertise
+            .map { [weak self] _ in
+                self?.detailState == .advertise
             }
             .compactMap { [weak self] state in
                 if state {
@@ -167,6 +180,25 @@ class TermsAgreeViewModel {
             .eraseToAnyPublisher()
         
         return TermsAgreeOutput(isAllAgreeOn: isAllAgreeOn, isNextButtonOn: nextButton, states: state, goToNext: goNext, handleBackButton: back)
+    }
+    
+    func transformDetail(_ input: DetailInput) -> DetailOutput {
+        let service = input.service
+            .compactMap { [weak self] _ in
+                self?.detailState = .service
+            }.eraseToAnyPublisher()
+        
+        let personal = input.personal
+            .compactMap { [weak self] _ in
+                self?.detailState = .personal
+            }.eraseToAnyPublisher()
+        
+        let advertise = input.advertise
+            .compactMap { [weak self] _ in
+                self?.detailState = .advertise
+            }.eraseToAnyPublisher()
+        
+        return DetailOutput(handleService: service, handlePersonal: personal, handleAdvertise: advertise)
     }
 }
 


### PR DESCRIPTION
## 📚 작업 설명
- 이용약관 상세 노션 페이지 웹뷰로 띄워서 구현
- 상세 페이지에서 동의 버튼을 누르면 약관 동의한 것으로 이용약관 페이지의 버튼 상태도 같이 변동

## 🔥 트러블 슈팅
### 1️⃣. WebView 구현 방식
WKWebKit, open safari, SFSafariViewController 중에서도 닫기 버튼을 커스텀하고 입력하는 것이 따로 없으며 앱 내에서 보여줄 것이기에  WKWebKit를 사용했다. WKWebKit에서도 html과 웹링크를 고민하고 있는데, 웹링크를 사용하게 될 것 같다. 

### 2️⃣. 상세 페이지 버튼과 기존 페이지 뷰모델 연결
TermsDetailViewController에서 "동의" 버튼을 눌렀을 때 TermsAgreeViewModel에 있는 TermsButtonStates가 바뀌어야 했다. Publisher를 고민하다 handleDetail이라는 PassthroughSubject<TermsDetailStates, Never>()를 만들어서 "동의" 버튼을 누르면 해당 뷰컨의 state를 send하도록 했다. 기존에 있는 TermsAgreeViewController의 버튼이 눌렸을 때의 로직과 연결하기 위해 main과 detail로 나누어서 Merge한 후 Merge한 Publisher를 잇는 걸로 구현했다. 
```swift
let mainPersonal = input.personal
      .handleEvents(receiveOutput: { [weak self] _ in
           self?.buttonStates.personal.toggle()
       })
       .share()
        
let detailPersonal = handleDetail
        .map { state in
            state == .personal
        }
        .compactMap { [weak self] state in
            if state {
                self?.buttonStates.personal = true
            }
        }
        .eraseToAnyPublisher()
        
let personal = Publishers.Merge(mainPersonal, detailPersonal)
```

### 3️⃣. state를 init으로 받는 뷰 컨트롤러를 DIContainer에 저장하기
TermsDetailViewController는 init으로 어떤 약관의 상세 페이지인지를 받는다. 
```swift
init(terms: TermsDetailStates, viewModel: TermsAgreeViewModel) {
    self.termsState = terms
    self.viewModel = viewModel
    super.init(nibName: nil, bundle: nil)
}
   
required init?(coder: NSCoder) {
    fatalError("init(coder:) has not been implemented")
}
```
이를 DIContainer에 어떤 식으로 저장할지 고민하다 detail을 위한 메서드를 따로 구현했다. 
```swift
func registerDetail(key: String, dependency: Any) {
    dependencies[key] = dependency
}
    
func resolveDetail<T>(_ type: T.Type, key: String) -> T {
    guard let value = dependencies[key] as? T else {
        fatalError()
    }
        
    return value
}
```
이게 좋은 방법인지는 잘 모르겠다...