### PR TITLE
[FEAT] 인터넷 연결 확인

### DIFF
--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -160,6 +160,7 @@
 		9293DCAF2C2C62AA00545B57 /* SharingCardViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DCAE2C2C62AA00545B57 /* SharingCardViewController.swift */; };
 		9293DCB12C2C63BF00545B57 /* SharingCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DCB02C2C63BF00545B57 /* SharingCardView.swift */; };
 		9293DCB32C2C640800545B57 /* SharingContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9293DCB22C2C640800545B57 /* SharingContainer.swift */; };
+		92CA2D062C2DF7850084CD5A /* InternetMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2D052C2DF7850084CD5A /* InternetMonitor.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -317,6 +318,7 @@
 		9293DCAE2C2C62AA00545B57 /* SharingCardViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingCardViewController.swift; sourceTree = "<group>"; };
 		9293DCB02C2C63BF00545B57 /* SharingCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingCardView.swift; sourceTree = "<group>"; };
 		9293DCB22C2C640800545B57 /* SharingContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharingContainer.swift; sourceTree = "<group>"; };
+		92CA2D052C2DF7850084CD5A /* InternetMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InternetMonitor.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -372,6 +374,7 @@
 				921694F92BF21F07006DC44A /* RequestBuilder.swift */,
 				921694FB2BF2202A006DC44A /* URLBuilder.swift */,
 				921694FD2BF2207A006DC44A /* APIProvider.swift */,
+				92CA2D052C2DF7850084CD5A /* InternetMonitor.swift */,
 			);
 			path = Network;
 			sourceTree = "<group>";
@@ -1047,6 +1050,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				921695632BFC6362006DC44A /* TermsAgreeRepositoryType.swift in Sources */,
+				92CA2D062C2DF7850084CD5A /* InternetMonitor.swift in Sources */,
 				921695652BFC67D0006DC44A /* TermsAgreeRepository.swift in Sources */,
 				9293DC8E2C233D8B00545B57 /* ImageManager.swift in Sources */,
 				9271F7F32C08993600586AFD /* StrengthRepository.swift in Sources */,

--- a/roome/roome/Application/AppDelegate.swift
+++ b/roome/roome/Application/AppDelegate.swift
@@ -14,15 +14,6 @@ import KakaoSDKAuth
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
     var isLogin: Bool = false 
-//    {
-//        didSet {
-//            Task { @MainActor in
-//                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
-//                    .changeRootViewController(SplashView(), animated: true)
-//            }
-//        }
-//    }
-
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         KakaoSDK.initSDK(appKey: Bundle.main.infoDictionary?["KakaoAppKey"] as! String)

--- a/roome/roome/Application/AppDelegate.swift
+++ b/roome/roome/Application/AppDelegate.swift
@@ -13,14 +13,16 @@ import KakaoSDKAuth
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    var isLogin: Bool = false {
-        didSet {
-            Task { @MainActor in
-                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
-                    .changeRootViewController(SplashView(), animated: true)
-            }
-        }
-    }
+    var isLogin: Bool = false 
+//    {
+//        didSet {
+//            Task { @MainActor in
+//                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?
+//                    .changeRootViewController(SplashView(), animated: true)
+//            }
+//        }
+//    }
+
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         KakaoSDK.initSDK(appKey: Bundle.main.infoDictionary?["KakaoAppKey"] as! String)
@@ -33,7 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
-    func appleAutomaticLogin() {
+    private func appleAutomaticLogin() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: KeyChain.read(key: .appleUserID) ?? "") { credentialState, error in
             switch credentialState {
@@ -45,7 +47,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     }
     
-    func kakaoAutomaticLogin() {
+    private func kakaoAutomaticLogin() {
         if AuthApi.hasToken() {
             UserApi.shared.accessTokenInfo { (_, error) in
                 if let error = error {

--- a/roome/roome/Application/AppDelegate.swift
+++ b/roome/roome/Application/AppDelegate.swift
@@ -26,6 +26,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         return true
     }
     
+    func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
+        return UIInterfaceOrientationMask.portrait
+    }
+    
     private func appleAutomaticLogin() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         appleIDProvider.getCredentialState(forUserID: KeyChain.read(key: .appleUserID) ?? "") { credentialState, error in

--- a/roome/roome/Application/SceneDelegate.swift
+++ b/roome/roome/Application/SceneDelegate.swift
@@ -29,10 +29,10 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         window = UIWindow(windowScene: windowScene)
         
+        DIManager.shared.registerAll()
         if connectionOptions.urlContexts.isEmpty {
             window?.rootViewController = SplashView()
         } else {
-            DIManager.shared.registerAll()
             self.scene(scene, openURLContexts: connectionOptions.urlContexts)
         }
         window?.makeKeyAndVisible()

--- a/roome/roome/DesignSystem/CustomUI/ProfileStateLineView.swift
+++ b/roome/roome/DesignSystem/CustomUI/ProfileStateLineView.swift
@@ -17,7 +17,7 @@ class ProfileStateLineView: UIView {
         self.colorCount = pageNumber
         self.grayCount = 11 - pageNumber
         super.init(frame: frame)
-        self.backgroundColor = .systemBackground
+        self.backgroundColor = .clear
     }
     
     required init?(coder: NSCoder) {

--- a/roome/roome/Infrastructure/Network/InternetMonitor.swift
+++ b/roome/roome/Infrastructure/Network/InternetMonitor.swift
@@ -1,0 +1,30 @@
+//
+//  InternetMonitor.swift
+//  roome
+//
+//  Created by minsong kim on 6/28/24.
+//
+
+import UIKit
+import Network
+
+class InternetMonitor {
+    private let monitor = NWPathMonitor()
+    private var monitorQueue = DispatchQueue.global()
+    
+    func startMonitoring() {
+        monitor.pathUpdateHandler = { path in
+            if path.status == .satisfied {
+                DispatchQueue.main.async {
+                    (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.isConnect = true
+                }
+            } else {
+                DispatchQueue.main.async {
+                    (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.isConnect = false
+                }
+            }
+        }
+        
+        monitor.start(queue: monitorQueue)
+    }
+}

--- a/roome/roome/Login/Presentation/LoginViewController.swift
+++ b/roome/roome/Login/Presentation/LoginViewController.swift
@@ -11,6 +11,42 @@ import Combine
 class LoginViewController: UIViewController {
     private let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first
     private lazy var errorPopUp = PopUpView(frame: window!.bounds, title: "카카오톡 미설치", description: "카카오톡의 설치 여부를 확인해주세요!", colorButtonTitle: "확인")
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "나만의 방탈출 라이프"
+        label.textAlignment = .center
+        label.textColor = .roomeMain
+        label.font = .boldHeadline3
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private lazy var logoImageView: UIImageView = {
+        let view = UIImageView(image: UIImage(resource: .logo).resize(newWidth: view.frame.width * 0.6).changeImageColor(.roomeMain))
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    //로그인 버튼
+    lazy var kakaoLoginButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(resource: .kakaoLoginButton).resize(newWidth: view.frame.width * 0.9), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    lazy var appleLoginButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(resource: .appleLoginButton).resize(newWidth: view.frame.width * 0.9), for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
     private var viewModel: LoginViewModel
     private var cancellables = Set<AnyCancellable>()
     
@@ -22,55 +58,39 @@ class LoginViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
-    let stackView: UIStackView = {
-        let stack = UIStackView()
-        stack.translatesAutoresizingMaskIntoConstraints = false
-        stack.axis = .vertical
-        stack.distribution = .equalCentering
-        stack.spacing = 4
-        
-        return stack
-    }()
-    //로그인 버튼
-    lazy var kakaoLoginButton: UIButton = {
-        let button = UIButton()
-        
-        var buttonConfiguration = UIButton.Configuration.plain()
-        buttonConfiguration.image = UIImage(resource: .kakaoLoginButton).resize(newWidth: view.frame.width * 0.9)
-        
-        button.configuration = buttonConfiguration
-        
-        return button
-    }()
-    
-    lazy var appleLoginButton: UIButton = {
-        let button = UIButton(type: .custom)
-        
-        var buttonConfiguration = UIButton.Configuration.plain()
-        buttonConfiguration.image = UIImage(resource: .appleLoginButton).resize(newWidth: view.frame.width * 0.9)
-        
-        button.configuration = buttonConfiguration
-        
-        return button
-    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = .disable
         configureUI()
         bind()
     }
     
     private func configureUI() {
-        view.addSubview(stackView)
-        stackView.addArrangedSubview(kakaoLoginButton)
-        stackView.addArrangedSubview(appleLoginButton)
+        view.addSubview(titleLabel)
+        view.addSubview(logoImageView)
+        view.addSubview(kakaoLoginButton)
+        view.addSubview(appleLoginButton)
         
         NSLayoutConstraint.activate([
-            stackView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            stackView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            stackView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+            titleLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 200),
+            titleLabel.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.6),
+            titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            
+            logoImageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+            logoImageView.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.6),
+            logoImageView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            logoImageView.heightAnchor.constraint(equalToConstant: 40),
+            
+            appleLoginButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -100),
+            appleLoginButton.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.9),
+            appleLoginButton.heightAnchor.constraint(equalToConstant: 50),
+            appleLoginButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            
+            kakaoLoginButton.bottomAnchor.constraint(equalTo: appleLoginButton.topAnchor, constant: -8),
+            kakaoLoginButton.widthAnchor.constraint(equalTo: view.widthAnchor, multiplier: 0.9),
+            kakaoLoginButton.heightAnchor.constraint(equalToConstant: 50),
+            kakaoLoginButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }
     

--- a/roome/roome/Main/Presentation/MyProfile/MyProfileCardViewController.swift
+++ b/roome/roome/Main/Presentation/MyProfile/MyProfileCardViewController.swift
@@ -22,7 +22,7 @@ class MyProfileCardViewController: UIViewController {
     //Profile View
     private let profileBackView: UIView = {
         let view = UIView()
-        view.backgroundColor = .lightGray
+        view.backgroundColor = .disable
         view.translatesAutoresizingMaskIntoConstraints = false
 
         return view

--- a/roome/roome/Main/Presentation/TabBarController.swift
+++ b/roome/roome/Main/Presentation/TabBarController.swift
@@ -19,12 +19,15 @@ class TabBarController: UITabBarController {
     private func setUpViewController() {
         let myProfile = DIContainer.shared.resolve(MyProfileViewController.self)
         let setting = DIContainer.shared.resolve(SettingViewController.self)
+        let attributes = [NSAttributedString.Key.font: UIFont.mediumCaption]
         
         myProfile.tabBarItem.image = UIImage(systemName: "person.fill")
         myProfile.tabBarItem.title = "프로필"
+        myProfile.tabBarItem.setTitleTextAttributes(attributes, for: .normal)
         
         setting.tabBarItem.image = UIImage(systemName: "gearshape.fill")
         setting.tabBarItem.title = "설정"
+        setting.tabBarItem.setTitleTextAttributes(attributes, for: .normal)
         
         viewControllers = [myProfile, setting]
     }

--- a/roome/roome/ProfileCreate/Presentation/ProfileCardViewController.swift
+++ b/roome/roome/ProfileCreate/Presentation/ProfileCardViewController.swift
@@ -22,7 +22,7 @@ class ProfileCardViewController: UIViewController {
     //Profile View
     private let profileBackView: UIView = {
         let view = UIView()
-        view.backgroundColor = .lightGray
+        view.backgroundColor = .disable
         view.translatesAutoresizingMaskIntoConstraints = false
 
         return view

--- a/roome/roome/ProfileSelect/Presentation/View/ActivityViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/ActivityViewController.swift
@@ -48,13 +48,13 @@ class ActivityViewController: UIViewController {
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(DislikeViewController.self)
                 
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             }).store(in: &cancellables)
         
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.tapNext

--- a/roome/roome/ProfileSelect/Presentation/View/ColorSelectViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/ColorSelectViewController.swift
@@ -57,16 +57,15 @@ class ColorSelectViewController: UIViewController{
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.handleNextPage
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-//                    let nextViewController = DIContainer.shared.resolve(ProfileViewController.self)
                 let nextViewController = ProfileCardViewController(viewModel: ProfileCardViewModel())
                 
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             }.store(in: &cancellables)
         
         output.tapNext

--- a/roome/roome/ProfileSelect/Presentation/View/DeviceAndLockViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/DeviceAndLockViewController.swift
@@ -47,13 +47,13 @@ class DeviceAndLockViewController: UIViewController {
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(ActivityViewController.self)
                 
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             }).store(in: &cancellables)
         
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.tapNext

--- a/roome/roome/ProfileSelect/Presentation/View/DislikeViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/DislikeViewController.swift
@@ -66,7 +66,7 @@ class DislikeViewController: UIViewController, ToastAlertable {
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.handleNextButton
@@ -76,7 +76,7 @@ class DislikeViewController: UIViewController, ToastAlertable {
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(ColorSelectViewController.self)
                 
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             }).store(in: &cancellables)
         
         output.tapNext

--- a/roome/roome/ProfileSelect/Presentation/View/GenreViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/GenreViewController.swift
@@ -67,7 +67,7 @@ class GenreViewController: UIViewController, ToastAlertable {
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.handleNextButton
@@ -76,7 +76,7 @@ class GenreViewController: UIViewController, ToastAlertable {
                 //연결 실패 시?
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(MBTIViewController.self)
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             })
             .store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/HintViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/HintViewController.swift
@@ -48,14 +48,14 @@ class HintViewController: UIViewController {
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(DeviceAndLockViewController.self)
                 
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             })
             .store(in: &cancellables)
         
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.tapNext

--- a/roome/roome/ProfileSelect/Presentation/View/HorrorPositionViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/HorrorPositionViewController.swift
@@ -47,13 +47,13 @@ class HorrorPositionViewController: UIViewController {
                 // 실패 시
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(HintViewController.self)
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             }).store(in: &cancellables)
         
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.tapNext

--- a/roome/roome/ProfileSelect/Presentation/View/ImportantFactorViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/ImportantFactorViewController.swift
@@ -66,7 +66,7 @@ class ImportantFactorViewController: UIViewController, ToastAlertable {
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.handleNextButton
@@ -76,7 +76,7 @@ class ImportantFactorViewController: UIViewController, ToastAlertable {
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(HorrorPositionViewController.self)
                 
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             })
             .store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
@@ -80,7 +80,7 @@ class MBTIViewController: UIViewController {
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.handleNextButton
@@ -90,7 +90,7 @@ class MBTIViewController: UIViewController {
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(StrengthViewController.self)
                 
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             })
             .store(in: &cancellables)
         

--- a/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/RoomCountViewController.swift
@@ -100,7 +100,7 @@ class RoomCountViewController: UIViewController {
         return label
     }()
     
-    lazy var profileCount = ProfileStateLineView(pageNumber: 1, frame: CGRect(x: 20, y: 50, width: view.frame.width * 0.9 - 10, height: view.frame.height))
+    lazy var profileCount = ProfileStateLineView(pageNumber: 1, frame: CGRect(x: 20, y: 60, width: view.frame.width * 0.9 - 10, height: view.frame.height))
     private let backButton = BackButton()
     private let nextButton = NextButton()
     private var nextButtonWidthConstraint: NSLayoutConstraint?
@@ -170,7 +170,7 @@ class RoomCountViewController: UIViewController {
                 }
             }, receiveValue: { _ in
                 let nextPage = DIContainer.shared.resolve(GenreViewController.self)
-                self.navigationController?.pushViewController(nextPage, animated: true)
+                self.navigationController?.pushViewController(nextPage, animated: false)
             })
             .store(in: &cancellables)
         
@@ -204,7 +204,7 @@ class RoomCountViewController: UIViewController {
         backButton.publisher(for: .touchUpInside)
             .throttle(for: 0.05, scheduler: RunLoop.main, latest: true)
             .sink { [weak self]  in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
     }
     

--- a/roome/roome/ProfileSelect/Presentation/View/StrengthViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/StrengthViewController.swift
@@ -69,7 +69,7 @@ class StrengthViewController: UIViewController, ToastAlertable {
         output.handleBackButton
             .throttle(for: 1, scheduler: RunLoop.main, latest: false)
             .sink { [weak self] _ in
-                self?.navigationController?.popViewController(animated: true)
+                self?.navigationController?.popViewController(animated: false)
             }.store(in: &cancellables)
         
         output.handleNextButton
@@ -79,7 +79,7 @@ class StrengthViewController: UIViewController, ToastAlertable {
             }, receiveValue: { [weak self] _ in
                 let nextViewController = DIContainer.shared.resolve(ImportantFactorViewController.self)
                     
-                self?.navigationController?.pushViewController(nextViewController, animated: true)
+                self?.navigationController?.pushViewController(nextViewController, animated: false)
             })
             .store(in: &cancellables)
         

--- a/roome/roome/Share/SharingCardViewController.swift
+++ b/roome/roome/Share/SharingCardViewController.swift
@@ -23,7 +23,7 @@ class SharingCardViewController: UIViewController {
     //Profile View
     private let profileBackView: UIView = {
         let view = UIView()
-        view.backgroundColor = .lightGray
+        view.backgroundColor = .disable
         view.translatesAutoresizingMaskIntoConstraints = false
 
         return view

--- a/roome/roome/SplashView.swift
+++ b/roome/roome/SplashView.swift
@@ -31,7 +31,6 @@ class SplashView: UIViewController {
         super.viewDidAppear(animated)
         if KeyChain.read(key: .hasToken) == "true" {
             Task { @MainActor in
-                DIManager.shared.registerAll()
                 do {
                     try await UserContainer.shared.updateUserInformation()
                     setIsLogin()
@@ -40,7 +39,6 @@ class SplashView: UIViewController {
                 }
             }
         } else {
-            DIManager.shared.registerAll()
             setIsLogin()
         }
     }


### PR DESCRIPTION
## 📚 작업 설명
- 인터넷 연결 확인
- 연결 없을 경우 PopUpView 띄우기

## 🔥 트러블 슈팅
### 1️⃣. 전역적으로 인터넷 체크 후 팝업 띄우기
앱이 동작하는 동안 계속 인터넷 연결을 체크하는 로직이 필요했다. 
때문에 AppDelegate나 SceneDelegate에서 관련 함수를 실행시켰다. 
이때 팝업 뷰를 띄우는 것이 문제가 되었는데 팝업 뷰를 window를 기준으로 띄워주기에 frame에 window의 bounds를 넣어 주어야 했다.
그런데 만일 시점상 windows가 nil인 상태면 팝업 뷰가 생성되지 않고 앱이 크러쉬가 났다. 
때문에 `func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions)` 함수에서 window가 생성된 이후에 PopUpView를 update하는 방법으로 변경하여 해결했다.

### 2️⃣. PassthroughSubject에서 에러를 보내고 난 후 연결 끊김.
닉네임을 한 번 틀리고 나면 Error를 발행하여 PassthroughSubject가 종료되는 오류가 있었다. 
때문에 Error 발생 이후엔 더 이상 다음 버튼이 작동하지 않았다. 
PassthroughSubject는 Error를 발행하면 구독을 종료하기에 일어난 문제였다. 
고민하다 타입을 PassthroughSubject<Result<Void, Error>,Never>로 바꾸어서 해결했다. 