### PR TITLE
[FEAT] 회원 탈퇴 플로우 

### DIFF
--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -147,6 +147,8 @@
 		92CA2DDB2C3EBD6C0084CD5A /* EditDislikeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DDA2C3EBD6C0084CD5A /* EditDislikeViewController.swift */; };
 		92CA2DDD2C3EC6000084CD5A /* EditColorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DDC2C3EC6000084CD5A /* EditColorViewController.swift */; };
 		92CA2DDF2C3ECD2D0084CD5A /* ProfileDefaultDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DDE2C3ECD2D0084CD5A /* ProfileDefaultDTO.swift */; };
+		92CA2DE22C3FEA1E0084CD5A /* WithdrawalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */; };
+		92CA2DE42C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -291,6 +293,8 @@
 		92CA2DDA2C3EBD6C0084CD5A /* EditDislikeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditDislikeViewController.swift; sourceTree = "<group>"; };
 		92CA2DDC2C3EC6000084CD5A /* EditColorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditColorViewController.swift; sourceTree = "<group>"; };
 		92CA2DDE2C3ECD2D0084CD5A /* ProfileDefaultDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDefaultDTO.swift; sourceTree = "<group>"; };
+		92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalViewController.swift; sourceTree = "<group>"; };
+		92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalCollectionViewCell.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -824,6 +828,7 @@
 				9293DC7C2C216EAD00545B57 /* UserCell.swift */,
 				9293DC7E2C216EDC00545B57 /* MyProfileCell.swift */,
 				9293DC9B2C29D7DB00545B57 /* SettingCollectionViewCell.swift */,
+				92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */,
 			);
 			path = Cell;
 			sourceTree = "<group>";
@@ -841,6 +846,7 @@
 		9293DC952C27DCB300545B57 /* Setting */ = {
 			isa = PBXGroup;
 			children = (
+				92CA2DE02C3FE9E10084CD5A /* Withdrawal */,
 				9256E55F2C0EFEAD00A50515 /* SettingViewController.swift */,
 				9256E5612C0EFFBB00A50515 /* SettingViewModel.swift */,
 				9293DC972C280F2C00545B57 /* SettingWebViewController.swift */,
@@ -888,6 +894,14 @@
 				92CA2DDC2C3EC6000084CD5A /* EditColorViewController.swift */,
 			);
 			path = EditProfileCard;
+			sourceTree = "<group>";
+		};
+		92CA2DE02C3FE9E10084CD5A /* Withdrawal */ = {
+			isa = PBXGroup;
+			children = (
+				92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */,
+			);
+			path = Withdrawal;
 			sourceTree = "<group>";
 		};
 		92DBD9F62BCFCF5900E299E2 = {
@@ -1094,6 +1108,7 @@
 				921695532BFB2A3D006DC44A /* UserDTO.swift in Sources */,
 				921695822BFE021C006DC44A /* BackButton.swift in Sources */,
 				9216959B2BFE65AC006DC44A /* ButtonCell.swift in Sources */,
+				92CA2DE42C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift in Sources */,
 				9271F7862BFEF9A700586AFD /* MBTIViewController.swift in Sources */,
 				9216955D2BFBBE2F006DC44A /* DIContainer.swift in Sources */,
 				921695412BF9008A006DC44A /* TermsAgreeViewController.swift in Sources */,
@@ -1127,6 +1142,7 @@
 				921695842BFE03AE006DC44A /* TitleLabel.swift in Sources */,
 				92CA2DD52C3EB7790084CD5A /* EditHintViewController.swift in Sources */,
 				9271F78C2BFF049F00586AFD /* ActivityViewController.swift in Sources */,
+				92CA2DE22C3FEA1E0084CD5A /* WithdrawalViewController.swift in Sources */,
 				9293DC982C280F2C00545B57 /* SettingWebViewController.swift in Sources */,
 				92CA2DDD2C3EC6000084CD5A /* EditColorViewController.swift in Sources */,
 				9293DCB32C2C640800545B57 /* SharingContainer.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		92CA2DE62C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */; };
 		92CA2DE82C402CEC0084CD5A /* WithdrawalAgreeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */; };
 		92CA2DEA2C415FCD0084CD5A /* WithdrawalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE92C415FCD0084CD5A /* WithdrawalViewModel.swift */; };
+		92CA2DEC2C425BF90084CD5A /* AgreeButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DEB2C425BF90084CD5A /* AgreeButton.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -301,6 +302,7 @@
 		92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalDetailViewController.swift; sourceTree = "<group>"; };
 		92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalAgreeViewController.swift; sourceTree = "<group>"; };
 		92CA2DE92C415FCD0084CD5A /* WithdrawalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalViewModel.swift; sourceTree = "<group>"; };
+		92CA2DEB2C425BF90084CD5A /* AgreeButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgreeButton.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -445,6 +447,7 @@
 				921695812BFE021B006DC44A /* BackButton.swift */,
 				921695872BFE0958006DC44A /* NextButton.swift */,
 				928474842C0DB4F9002C3B4C /* SizeButton.swift */,
+				92CA2DEB2C425BF90084CD5A /* AgreeButton.swift */,
 			);
 			path = Button;
 			sourceTree = "<group>";
@@ -1050,6 +1053,7 @@
 				92CA2DC92C3CBCDF0084CD5A /* EditRoomCountViewController.swift in Sources */,
 				921695A52BFE786B006DC44A /* DislikeViewController.swift in Sources */,
 				9293DC9C2C29D7DB00545B57 /* SettingCollectionViewCell.swift in Sources */,
+				92CA2DEC2C425BF90084CD5A /* AgreeButton.swift in Sources */,
 				9271F79C2C009E9F00586AFD /* ImportantFactorViewModel.swift in Sources */,
 				9293DC7D2C216EAD00545B57 /* UserCell.swift in Sources */,
 				9271F7882BFF027000586AFD /* HorrorPositionViewController.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		92CA2DE42C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */; };
 		92CA2DE62C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */; };
 		92CA2DE82C402CEC0084CD5A /* WithdrawalAgreeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */; };
+		92CA2DEA2C415FCD0084CD5A /* WithdrawalViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE92C415FCD0084CD5A /* WithdrawalViewModel.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -299,6 +300,7 @@
 		92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalCollectionViewCell.swift; sourceTree = "<group>"; };
 		92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalDetailViewController.swift; sourceTree = "<group>"; };
 		92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalAgreeViewController.swift; sourceTree = "<group>"; };
+		92CA2DE92C415FCD0084CD5A /* WithdrawalViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalViewModel.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -906,6 +908,7 @@
 				92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */,
 				92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */,
 				92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */,
+				92CA2DE92C415FCD0084CD5A /* WithdrawalViewModel.swift */,
 			);
 			path = Withdrawal;
 			sourceTree = "<group>";
@@ -1096,6 +1099,7 @@
 				9216959D2BFE72D1006DC44A /* StrengthViewController.swift in Sources */,
 				9271F79E2C00A1B400586AFD /* HorrorPositionViewModel.swift in Sources */,
 				928474852C0DB4F9002C3B4C /* SizeButton.swift in Sources */,
+				92CA2DEA2C415FCD0084CD5A /* WithdrawalViewModel.swift in Sources */,
 				921695692BFC8839006DC44A /* NicknameRepositoryType.swift in Sources */,
 				9293DC812C22E70700545B57 /* TabBarController.swift in Sources */,
 				921694FE2BF2207A006DC44A /* APIProvider.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -150,6 +150,7 @@
 		92CA2DE22C3FEA1E0084CD5A /* WithdrawalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */; };
 		92CA2DE42C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */; };
 		92CA2DE62C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */; };
+		92CA2DE82C402CEC0084CD5A /* WithdrawalAgreeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -297,6 +298,7 @@
 		92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalViewController.swift; sourceTree = "<group>"; };
 		92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalCollectionViewCell.swift; sourceTree = "<group>"; };
 		92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalDetailViewController.swift; sourceTree = "<group>"; };
+		92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalAgreeViewController.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -903,6 +905,7 @@
 			children = (
 				92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */,
 				92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */,
+				92CA2DE72C402CEC0084CD5A /* WithdrawalAgreeViewController.swift */,
 			);
 			path = Withdrawal;
 			sourceTree = "<group>";
@@ -1054,6 +1057,7 @@
 				921694FA2BF21F07006DC44A /* RequestBuilder.swift in Sources */,
 				9216950F2BF33E9D006DC44A /* LoginDTO.swift in Sources */,
 				92CA2D0B2C3385D00084CD5A /* ProfileSelectUseCase.swift in Sources */,
+				92CA2DE82C402CEC0084CD5A /* WithdrawalAgreeViewController.swift in Sources */,
 				921695012BF220A6006DC44A /* NetworkError.swift in Sources */,
 				9256E55A2C0EFC0D00A50515 /* UILabel+.swift in Sources */,
 				9271F7CC2C00E65800586AFD /* ColorSelectViewModel.swift in Sources */,

--- a/roome/roome.xcodeproj/project.pbxproj
+++ b/roome/roome.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		92CA2DDF2C3ECD2D0084CD5A /* ProfileDefaultDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DDE2C3ECD2D0084CD5A /* ProfileDefaultDTO.swift */; };
 		92CA2DE22C3FEA1E0084CD5A /* WithdrawalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */; };
 		92CA2DE42C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */; };
+		92CA2DE62C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */; };
 		92DBDA032BCFCF5900E299E2 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */; };
 		92DBDA052BCFCF5900E299E2 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */; };
 		92DBDA072BCFCF5900E299E2 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92DBDA062BCFCF5900E299E2 /* LoginViewController.swift */; };
@@ -295,6 +296,7 @@
 		92CA2DDE2C3ECD2D0084CD5A /* ProfileDefaultDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileDefaultDTO.swift; sourceTree = "<group>"; };
 		92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalViewController.swift; sourceTree = "<group>"; };
 		92CA2DE32C3FF5590084CD5A /* WithdrawalCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalCollectionViewCell.swift; sourceTree = "<group>"; };
+		92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WithdrawalDetailViewController.swift; sourceTree = "<group>"; };
 		92DBD9FF2BCFCF5900E299E2 /* roome.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = roome.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		92DBDA022BCFCF5900E299E2 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		92DBDA042BCFCF5900E299E2 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -900,6 +902,7 @@
 			isa = PBXGroup;
 			children = (
 				92CA2DE12C3FEA1E0084CD5A /* WithdrawalViewController.swift */,
+				92CA2DE52C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift */,
 			);
 			path = Withdrawal;
 			sourceTree = "<group>";
@@ -1054,6 +1057,7 @@
 				921695012BF220A6006DC44A /* NetworkError.swift in Sources */,
 				9256E55A2C0EFC0D00A50515 /* UILabel+.swift in Sources */,
 				9271F7CC2C00E65800586AFD /* ColorSelectViewModel.swift in Sources */,
+				92CA2DE62C3FFE8F0084CD5A /* WithdrawalDetailViewController.swift in Sources */,
 				921695A32BFE773C006DC44A /* DeviceAndLockViewController.swift in Sources */,
 				9293DC6D2C12167F00545B57 /* UIFontMetrics+.swift in Sources */,
 				92CA2DD92C3EBB990084CD5A /* EditActivityViewController.swift in Sources */,

--- a/roome/roome/Application/AppDelegate.swift
+++ b/roome/roome/Application/AppDelegate.swift
@@ -18,6 +18,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
         KakaoSDK.initSDK(appKey: Bundle.main.infoDictionary?["KakaoAppKey"] as! String)
         UITextField.appearance().tintColor = .roomeMain
+        UITextView.appearance().tintColor = .roomeMain
         if KeyChain.read(key: .isAppleLogin) == "true" {
             appleAutomaticLogin()
         } else {

--- a/roome/roome/Application/DIManager.swift
+++ b/roome/roome/Application/DIManager.swift
@@ -168,6 +168,14 @@ class DIManager {
         
         let tabBarController = TabBarController()
         DIContainer.shared.register(TabBarController.self, dependency: tabBarController)
+        
+        let withdrawalViewModel = WithdrawalViewModel(loginUseCase: DIContainer.shared.resolve(LoginUseCase.self))
+        let withdrawalViewController = WithdrawalViewController(viewModel: withdrawalViewModel)
+        let withdrawalDetailViewController = WithdrawalDetailViewController(viewModel: withdrawalViewModel)
+        let withdrawalAgreeViewController = WithdrawalAgreeViewController(viewModel: withdrawalViewModel)
+        DIContainer.shared.register(WithdrawalViewController.self, dependency: withdrawalViewController)
+        DIContainer.shared.register(WithdrawalDetailViewController.self, dependency: withdrawalDetailViewController)
+        DIContainer.shared.register(WithdrawalAgreeViewController.self, dependency: withdrawalAgreeViewController)
     }
     
     private func registerExtraDependency() {

--- a/roome/roome/DesignSystem/CustomUI/Button/AgreeButton.swift
+++ b/roome/roome/DesignSystem/CustomUI/Button/AgreeButton.swift
@@ -1,0 +1,70 @@
+//
+//  AgreeButton.swift
+//  roome
+//
+//  Created by minsong kim on 7/13/24.
+//
+
+import UIKit
+
+class AgreeButton: UIButton {
+    private let agreeImageView: UIImageView = {
+        let view = UIImageView(image: UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.disable).resize(newWidth: 24))
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private let agreeTitleLabel: UILabel = {
+        let label = UILabel()
+        label.font = .regularBody2
+        label.textColor = .label
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+
+    
+    override init(frame: CGRect = .zero) {
+        super.init(frame: frame)
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.backgroundColor = .clear
+    }
+    
+    convenience init(title: String, image: UIImage? = nil) {
+        self.init()
+        configureUI()
+        self.agreeTitleLabel.text = title
+        
+        if let image {
+            agreeImageView.image = image
+        }
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            if isSelected {
+                self.agreeImageView.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.roomeMain).resize(newWidth: 24)
+            } else {
+                self.agreeImageView.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.disable).resize(newWidth: 24)
+            }
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureUI() {
+        self.addSubview(agreeImageView)
+        self.addSubview(agreeTitleLabel)
+        
+        NSLayoutConstraint.activate([
+            agreeImageView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
+            agreeImageView.topAnchor.constraint(equalTo: self.safeAreaLayoutGuide.topAnchor),
+            
+            agreeTitleLabel.leadingAnchor.constraint(equalTo: agreeImageView.trailingAnchor, constant: 8),
+            agreeTitleLabel.centerYAnchor.constraint(equalTo: agreeImageView.centerYAnchor)
+        ])
+    }
+}

--- a/roome/roome/DesignSystem/CustomUI/PopUpView.swift
+++ b/roome/roome/DesignSystem/CustomUI/PopUpView.swift
@@ -87,6 +87,8 @@ class PopUpView: UIView {
         return button
     }()
     
+    private var cancellables = Set<AnyCancellable>()
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.layer.backgroundColor = UIColor(red: 0, green: 0, blue: 0, alpha: 0.3).cgColor
@@ -121,6 +123,14 @@ class PopUpView: UIView {
     
     func publisherWhiteButton() -> AnyPublisher<Void, Never> {
         whiteButton.publisher(for: .touchUpInside).eraseToAnyPublisher()
+    }
+    
+    func dismissViewWithColorButton() {
+        colorButton.publisher(for: .touchUpInside)
+            .sink { [weak self] in
+                self?.removeFromSuperview()
+            }
+            .store(in: &cancellables)
     }
     
     func updatePopUpView(title: String, description: String, whiteButtonTitle: String? = nil, colorButtonTitle: String) {

--- a/roome/roome/Login/Presentation/LoginViewController.swift
+++ b/roome/roome/Login/Presentation/LoginViewController.swift
@@ -118,7 +118,7 @@ class LoginViewController: UIViewController {
                             self.window?.addSubview(self.errorPopUp)
                         }
                     } else {
-                        self.errorPopUp.updatePopUpView(title: "에러 발생", description: "다시 시도해주세요.", colorButtonTitle: "확인")
+                        self.errorPopUp.updatePopUpView(title: "로그인을 취소했어요", description: "다시 시도해주세요.", colorButtonTitle: "다시 시도")
                         self.window?.addSubview(self.errorPopUp)
                     }
                 }

--- a/roome/roome/Main/Presentation/CustomUI/Cell/WithdrawalCollectionViewCell.swift
+++ b/roome/roome/Main/Presentation/CustomUI/Cell/WithdrawalCollectionViewCell.swift
@@ -1,0 +1,54 @@
+//
+//  WithdrawalCollectionViewCell.swift
+//  roome
+//
+//  Created by minsong kim on 7/11/24.
+//
+
+import UIKit
+
+class WithdrawalCollectionViewCell: UICollectionViewListCell {
+    static let id = "WithdrawalCollectionViewCell"
+    private let label: UILabel = {
+        let label = PaddingLabel(padding: UIEdgeInsets(top: 19, left: 24, bottom: 19, right: 24))
+        label.textColor = .label
+        label.font = .regularBody1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        configureLabel()
+        accessories = [.disclosureIndicator(options: .init(reservedLayoutWidth: .custom(50)))]
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override var isSelected: Bool {
+        didSet {
+            self.backgroundColor = .systemBackground
+        }
+    }
+    
+    func configureCell(title: String) {
+        label.text = title
+    }
+    
+    private func configureLabel() {
+        self.addSubview(label)
+        self.backgroundColor = .systemBackground
+        
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            label.topAnchor.constraint(equalTo: contentView.topAnchor),
+            label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            label.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+            label.centerXAnchor.constraint(equalTo: contentView.centerXAnchor)
+        ])
+    }
+}

--- a/roome/roome/Main/Presentation/EditProfileCard/EditMBTIViewController.swift
+++ b/roome/roome/Main/Presentation/EditProfileCard/EditMBTIViewController.swift
@@ -27,21 +27,7 @@ class EditMBTIViewController: UIViewController {
     private lazy var flowLayout = self.createFlowLayout()
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout)
     
-    private let willNotAddButton: UIButton = {
-        var configuration = UIButton.Configuration.plain()
-        configuration.baseForegroundColor = .label
-        configuration.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.gray).resize(newWidth: 24)
-        configuration.imagePadding = 8
-        configuration.contentInsets = NSDirectionalEdgeInsets(top: 15, leading: 24, bottom: 10, trailing: 20)
-        configuration.title = "프로필에 추가하지 않을래요"
-        
-        let button = UIButton(configuration: configuration)
-        button.titleLabel?.font = .regularBody2
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.contentHorizontalAlignment = .leading
-        
-        return button
-    }()
+    private let willNotAddButton = AgreeButton(title: "프로필에 추가하지 않을래요")
     
     var viewModel: MBTIViewModel
     var cancellables = Set<AnyCancellable>()
@@ -128,12 +114,11 @@ class EditMBTIViewController: UIViewController {
         
         viewModel.output.handleNotAddButton
             .sink { [weak self] willNotAdd in
+                self?.willNotAddButton.isSelected = willNotAdd
                 if willNotAdd {
-                    self?.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.roomeMain).resize(newWidth: 24)
                     _ = self?.collectionView.visibleCells.map { $0.isSelected = false }
                     self?.collectionView.reloadData()
                 } else {
-                    self?.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.gray).resize(newWidth: 24)
                     _ = self?.collectionView.visibleCells
                         .compactMap { $0 as? ButtonCell }
                         .map { $0.isChecked = false }
@@ -196,9 +181,9 @@ class EditMBTIViewController: UIViewController {
         view.addSubview(willNotAddButton)
         
         NSLayoutConstraint.activate([
-            willNotAddButton.topAnchor.constraint(equalTo: collectionView.bottomAnchor),
-            willNotAddButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            willNotAddButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            willNotAddButton.topAnchor.constraint(equalTo: collectionView.bottomAnchor, constant: 12),
+            willNotAddButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            willNotAddButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
         ])
     }
     

--- a/roome/roome/Main/Presentation/Setting/SettingViewController.swift
+++ b/roome/roome/Main/Presentation/Setting/SettingViewController.swift
@@ -18,15 +18,6 @@ class SettingViewController: UIViewController, UICollectionViewDelegate {
                                              description: "정말 로그아웃하시겠어요?",
                                              whiteButtonTitle: "취소",
                                              colorButtonTitle: "로그아웃")
-    private lazy var withdrawalPopUp = PopUpView(frame: window!.bounds,
-                                                 title: "정말로 탈퇴하시겠어요?",
-                                                 description: "지금까지 작성된 모든 정보가 삭제되고,\n복구할 수 없어요",
-                                                 whiteButtonTitle: "취소",
-                                                 colorButtonTitle: "탈퇴")
-    private lazy var successWithdrawalPopUp = PopUpView(frame: window!.bounds,
-                                                        title: "탈퇴 완료",
-                                                        description: "탈퇴 처리가 성공적으로 완료되었습니다.",
-                                                        colorButtonTitle: "확인")
     private lazy var errorPopUp = PopUpView(frame: window!.bounds,
                                             title: "에러 발생",
                                             description: "다시 시도해주세요",
@@ -68,10 +59,9 @@ class SettingViewController: UIViewController, UICollectionViewDelegate {
         
         viewModel.output.handleWithdrawalButton
             .sink { [weak self] _ in
-                guard let self else {
-                    return
-                }
-                self.window?.addSubview(self.withdrawalPopUp)
+                let next = DIContainer.shared.resolve(WithdrawalViewController.self)
+                next.modalPresentationStyle = .fullScreen
+                self?.present(next, animated: false)
             }
             .store(in: &cancellables)
         
@@ -90,22 +80,9 @@ class SettingViewController: UIViewController, UICollectionViewDelegate {
             }
             .store(in: &cancellables)
         
-        withdrawalPopUp.publisherWhiteButton()
-            .sink { [weak self] _ in
-                self?.withdrawalPopUp.removeFromSuperview()
-            }
-            .store(in: &cancellables)
-        
         logoutPopUp.publisherColorButton()
             .sink { [weak self] _ in
                 self?.viewModel.input.tappedLogout.send()
-            }
-            .store(in: &cancellables)
-        
-        withdrawalPopUp.publisherColorButton()
-            .sink { [weak self] _ in
-                self?.viewModel.input.tappedWithdrawal.send()
-                self?.withdrawalPopUp.removeFromSuperview()
             }
             .store(in: &cancellables)
         
@@ -135,36 +112,6 @@ class SettingViewController: UIViewController, UICollectionViewDelegate {
             }
             .store(in: &cancellables)
         
-        viewModel.output.handleWithdrawal
-            .throttle(for: 1, scheduler: RunLoop.main, latest: false)
-            .sink { [weak self] completion in
-                switch completion {
-                case .finished:
-                    print("withdrawal finish")
-                case .failure(let error):
-                    print("withdrawal fail: \(error)")
-                    UserContainer.shared.resetUser()
-                    DIContainer.shared.removeAll()
-                    DIManager.shared.registerAll()
-                    let next = DIContainer.shared.resolve(LoginViewController.self)
-                    self?.window?.rootViewController?.dismiss(animated: false)
-                    (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootViewController(next, animated: true)
-                }
-            } receiveValue: { [weak self] _ in
-                guard let self else {
-                    return
-                }
-                print("✨withdrawal Success")
-                UserContainer.shared.resetUser()
-                DIContainer.shared.removeAll()
-                DIManager.shared.registerAll()
-                let next = DIContainer.shared.resolve(LoginViewController.self)
-                window?.rootViewController?.dismiss(animated: false)
-                (UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate)?.changeRootViewController(next, animated: true)
-                window?.addSubview(successWithdrawalPopUp)
-            }
-            .store(in: &cancellables)
-        
         viewModel.output.handleUpdate
             .sink { completion in
                 switch completion {
@@ -181,12 +128,6 @@ class SettingViewController: UIViewController, UICollectionViewDelegate {
         errorPopUp.publisherColorButton()
             .sink { [weak self] in
                 self?.errorPopUp.removeFromSuperview()
-            }
-            .store(in: &cancellables)
-        
-        successWithdrawalPopUp.publisherColorButton()
-            .sink { [weak self] in
-                self?.successWithdrawalPopUp.removeFromSuperview()
             }
             .store(in: &cancellables)
     }

--- a/roome/roome/Main/Presentation/Setting/SettingViewModel.swift
+++ b/roome/roome/Main/Presentation/Setting/SettingViewModel.swift
@@ -5,16 +5,14 @@
 //  Created by minsong kim on 6/4/24.
 //
 
-import Foundation
 import Combine
-import AuthenticationServices
 import KakaoSDKUser
+import UIKit
 
 class SettingViewModel: NSObject {
     struct Input {
         let selectCell = PassthroughSubject<SettingItem?, Never>()
         let tappedLogout = PassthroughSubject<Void, Never>()
-        let tappedWithdrawal = PassthroughSubject<Void, Never>()
     }
     
     struct Output {
@@ -22,7 +20,6 @@ class SettingViewModel: NSObject {
         let handleLogoutButton = PassthroughSubject<Void, Never>()
         let handleWithdrawalButton = PassthroughSubject<Void, Never>()
         let handleLogout = PassthroughSubject<Void, Error>()
-        let handleWithdrawal = PassthroughSubject<Void, Error>()
         let handleSelectError = PassthroughSubject<Void, Never>()
         let handleUpdate = PassthroughSubject<Void, Error>()
     }
@@ -82,16 +79,6 @@ class SettingViewModel: NSObject {
                 }
             }
             .store(in: &cancellables)
-        
-        input.tappedWithdrawal
-            .sink { [weak self] _ in
-                if KeyChain.read(key: .isAppleLogin) == "true" {
-                    self?.handleAppleSignOut()
-                } else {
-                    self?.handleKakaoSignOut()
-                }
-            }
-            .store(in: &cancellables)
     }
     
     private func updateVersion() {
@@ -145,68 +132,6 @@ class SettingViewModel: NSObject {
                         self.output.handleLogout.send(completion: .failure(error))
                     }
                 }
-            }
-        }
-    }
-    
-    private func handleAppleSignOut() {
-        let appleIDProvider = ASAuthorizationAppleIDProvider()
-        let request = appleIDProvider.createRequest()
-        request.requestedScopes = [.fullName, .email]
-        
-        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-        authorizationController.delegate = self
-        authorizationController.performRequests()
-    }
-    
-    private func handleKakaoSignOut() {
-        UserApi.shared.unlink { [self] error in
-            if let error {
-                print(error)
-            } else {
-                print("unlink() success")
-                
-                let bodyJSON: [String: Any?] = ["provider": LoginProvider.kakao.name,
-                                               "code": nil]
-                
-                //탈퇴 시켜줘
-                Task {
-                    do {
-                        try await self.loginUseCase?.signOutWithAPI(body: bodyJSON)
-                        KeyChain.delete(key: .accessToken)
-                        KeyChain.delete(key: .refreshToken)
-                        KeyChain.delete(key: .hasToken)
-                        output.handleWithdrawal.send()
-                    } catch(let error) {
-                        output.handleWithdrawal.send(completion: .failure(error))
-                    }
-                }
-            }
-        }
-    }
-}
-
-extension SettingViewModel: ASAuthorizationControllerDelegate {
-    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
-        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
-            return
-        }
-        //TODO: - 도메인에 넘겨줄 body Type 따로 정의해서 분리하기
-        let bodyJSON: [String: Any] = ["provider": LoginProvider.apple.name,
-                                        "code": String(data: credential.authorizationCode ?? Data(), encoding: .utf8) ?? ""]
-        
-        Task {
-            do {
-                try await loginUseCase?.signOutWithAPI(body: bodyJSON)
-                //키체인에 유저 정보 삭제
-                KeyChain.delete(key: .accessToken)
-                KeyChain.delete(key: .refreshToken)
-                KeyChain.delete(key: .hasToken)
-                KeyChain.delete(key: .isAppleLogin)
-                KeyChain.delete(key: .appleUserID)
-                output.handleWithdrawal.send()
-            } catch(let error) {
-                output.handleWithdrawal.send(completion: .failure(error))
             }
         }
     }

--- a/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalAgreeViewController.swift
+++ b/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalAgreeViewController.swift
@@ -1,0 +1,155 @@
+//
+//  WithdrawalAgreeViewController.swift
+//  roome
+//
+//  Created by minsong kim on 7/12/24.
+//
+
+import UIKit
+
+class WithdrawalAgreeViewController: UIViewController {
+    private let window = (UIApplication.shared.connectedScenes.first as? UIWindowScene)?.windows.first
+    
+    private lazy var withdrawalPopUp = PopUpView(frame: window!.bounds,
+                                                 title: "정말로 탈퇴하시겠어요?",
+                                                 description: "지금까지 작성된 모든 정보가 삭제되고,\n복구할 수 없어요",
+                                                 whiteButtonTitle: "취소",
+                                                 colorButtonTitle: "탈퇴")
+    
+    private lazy var successWithdrawalPopUp = PopUpView(frame: window!.bounds,
+                                                        title: "탈퇴 완료",
+                                                        description: "탈퇴 처리가 성공적으로 완료되었습니다.",
+                                                        colorButtonTitle: "확인")
+    
+    private let backButton = BackButton()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "탈퇴하기 전에 확인해 주세요"
+        label.sizeToFit()
+        label.textAlignment = .left
+        label.font = .boldTitle2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let dotView: UIImageView = {
+        let view = UIImageView(image: UIImage(systemName: "circlebadge.fill")?.changeImageColor(.label).resize(newWidth: 4))
+        view.contentMode = .center
+        view.translatesAutoresizingMaskIntoConstraints = false
+        
+        return view
+    }()
+    
+    private let descriptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "작성하신 계정, 프로필 정보, 후기와 같은 모든 정보가 삭제되고 재가입하더라도 복구할 수 없어요."
+        label.numberOfLines = 0
+        label.font = .regularBody2
+        label.textAlignment = .left
+        label.textColor = .darkGray
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let agreeButton: UIButton = {
+        var configuration = UIButton.Configuration.plain()
+        configuration.baseForegroundColor = .label
+        configuration.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.disable).resize(newWidth: 24)
+        configuration.titleLineBreakMode = .byCharWrapping
+        configuration.imagePadding = 8
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 0, trailing: 0)
+        configuration.title = "안내사항을 모두 확인하였으며, 이에 동의합니다."
+        
+        let button = UIButton(configuration: configuration)
+        button.titleLabel?.font = .regularBody2
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.contentHorizontalAlignment = .leading
+        
+        return button
+    }()
+    
+    private let nextButton = NextButton(title: "탈퇴하기", backgroundColor: .roomeMain, tintColor: .white)
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        view.backgroundColor = .systemBackground
+        configureUI()
+        nextButton.isEnabled = false
+    }
+    
+    private func configureUI() {
+        configureNavigationBar()
+        configureTitle()
+        configureDescription()
+        configureAgreeButton()
+        configureNextButton()
+    }
+    
+    private func configureNavigationBar() {
+        view.addSubview(backButton)
+        
+        NSLayoutConstraint.activate([
+            backButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            backButton.widthAnchor.constraint(equalToConstant: 24),
+            backButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+        ])
+    }
+
+    private func configureTitle() {
+        view.addSubview(titleLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: backButton.bottomAnchor, constant: 24),
+            titleLabel.leadingAnchor.constraint(equalTo: backButton.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24)
+        ])
+    }
+    
+    private func configureDescription() {
+        view.addSubview(dotView)
+        view.addSubview(descriptionLabel)
+        
+        NSLayoutConstraint.activate([
+            dotView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            dotView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 32),
+            dotView.heightAnchor.constraint(equalToConstant: 24),
+            dotView.widthAnchor.constraint(equalToConstant: 24),
+            
+            descriptionLabel.leadingAnchor.constraint(equalTo: dotView.trailingAnchor),
+            descriptionLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            descriptionLabel.topAnchor.constraint(equalTo: dotView.topAnchor, constant: -4),
+            descriptionLabel.heightAnchor.constraint(greaterThanOrEqualToConstant: 50)
+        ])
+    }
+    
+    private func configureAgreeButton() {
+        view.addSubview(agreeButton)
+        
+        NSLayoutConstraint.activate([
+            agreeButton.topAnchor.constraint(equalTo: descriptionLabel.bottomAnchor),
+            agreeButton.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            agreeButton.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor)
+        ])
+    }
+    
+    private func configureNextButton() {
+        view.addSubview(nextButton)
+        
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+            nextButton.heightAnchor.constraint(equalToConstant: 50),
+            nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            nextButton.widthAnchor.constraint(equalToConstant: view.frame.width * 0.9)
+        ])
+    }
+}
+
+//#Preview {
+//    let vc = WithdrawalAgreeViewController()
+//    
+//    return vc
+//}

--- a/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalDetailViewController.swift
+++ b/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalDetailViewController.swift
@@ -1,0 +1,212 @@
+//
+//  WithdrawalDetailViewController.swift
+//  roome
+//
+//  Created by minsong kim on 7/11/24.
+//
+
+import UIKit
+
+class WithdrawalDetailViewController: UIViewController {
+    private let placeHolderText = "후기 작성 시 유의사항 한 번 확인하기!\n후기를 보는 사용자와 사업자에게 상처가 되는\n욕설, 비방, 명예훼손성 표현은 사용하지 말아주세요"
+    private let backButton = BackButton()
+    
+    private let jumpButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("넘어가기", for: .normal)
+        button.titleLabel?.font = .boldTitle3
+        button.setTitleColor(.label, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "더 나은 루미가 될 수 있도록\n의견을 들려주세요"
+        label.numberOfLines = 2
+        label.sizeToFit()
+        label.textAlignment = .left
+        label.font = .boldTitle2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private lazy var textView: UITextView = {
+        let view = UITextView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.backgroundColor = .systemGray6
+        view.layer.cornerRadius = 10
+        view.font = .regularBody2
+        view.text = placeHolderText
+        view.textColor = .gray
+        view.textContainerInset = UIEdgeInsets(top: 14, left: 16, bottom: 14, right: 16)
+        
+        return view
+    }()
+    
+    lazy var remainCountLabel: UILabel = {
+        let label = UILabel()
+        label.text = "/3000"
+        label.font = .mediumCaption
+        label.textColor = .label
+        label.textAlignment = .right
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private let nextButton = NextButton(title: "확인", backgroundColor: .roomeMain, tintColor: .white)
+    private var nextButtonWidthConstraint: NSLayoutConstraint?
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureUI()
+        
+        textView.delegate = self
+    }
+    
+    private func configureUI() {
+        configureNavigationBar()
+        configureTitle()
+        configureTextView()
+        configureNextButton()
+        registerKeyboardListener()
+    }
+    
+    private func configureNavigationBar() {
+        view.addSubview(backButton)
+        view.addSubview(jumpButton)
+        
+        NSLayoutConstraint.activate([
+            backButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            backButton.widthAnchor.constraint(equalToConstant: 24),
+            backButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+            
+            jumpButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            jumpButton.centerYAnchor.constraint(equalTo: backButton.centerYAnchor)
+        ])
+    }
+    
+    private func configureTitle() {
+        view.addSubview(titleLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: backButton.bottomAnchor, constant: 24),
+            titleLabel.leadingAnchor.constraint(equalTo: backButton.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24)
+        ])
+    }
+    
+    private func configureTextView() {
+        view.addSubview(textView)
+        view.addSubview(remainCountLabel)
+        
+        NSLayoutConstraint.activate([
+            textView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 24),
+            textView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            textView.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            textView.heightAnchor.constraint(equalToConstant: 150),
+            
+            remainCountLabel.topAnchor.constraint(equalTo: textView.bottomAnchor, constant: 4),
+            remainCountLabel.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
+            remainCountLabel.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor)
+        ])
+    }
+    
+    private func configureCountLabel() {
+        view.addSubview(remainCountLabel)
+        
+        NSLayoutConstraint.activate([
+        
+        ])
+    }
+    
+    private func configureNextButton() {
+        view.addSubview(nextButton)
+        
+        nextButtonWidthConstraint = nextButton.widthAnchor.constraint(equalToConstant: view.frame.width * 0.9)
+        nextButtonWidthConstraint?.isActive = true
+        
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor),
+            nextButton.heightAnchor.constraint(equalToConstant: 50),
+            nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
+        ])
+    }
+    
+    private func updateCountLabel(characterCount: Int) {
+            remainCountLabel.text = "\(characterCount)/3000"
+        }
+}
+
+extension WithdrawalDetailViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == placeHolderText {
+            textView.text = nil
+            textView.textColor = .label
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = placeHolderText
+            textView.textColor = .gray
+            remainCountLabel.text = "/3000"
+        }
+    }
+    
+    func textView(_ textView: UITextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+            let inputString = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let oldString = textView.text, let newRange = Range(range, in: oldString) else { return true }
+            let newString = oldString.replacingCharacters(in: newRange, with: inputString).trimmingCharacters(in: .whitespacesAndNewlines)
+
+            let characterCount = newString.count
+            guard characterCount <= 3000 else { return false }
+            remainCountLabel.text = "\(characterCount)/3000"
+
+            return true
+        }
+}
+
+extension WithdrawalDetailViewController {
+    private func registerKeyboardListener() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillShow(_:)),
+            name: UIResponder.keyboardWillShowNotification,
+            object: nil
+        )
+        
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(keyboardWillHide(_:)),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+    }
+    
+    @objc private func keyboardWillShow(_ notification: Notification) {
+        nextButton.layer.cornerRadius = 0
+        
+        nextButtonWidthConstraint?.isActive = false
+        nextButtonWidthConstraint = nextButton.widthAnchor.constraint(equalToConstant: view.frame.width)
+        nextButtonWidthConstraint?.isActive = true
+    }
+    
+    @objc private func keyboardWillHide(_ notification: Notification) {
+        nextButton.layer.cornerRadius = 10
+        
+        nextButtonWidthConstraint?.isActive = false
+        nextButtonWidthConstraint = nextButton.widthAnchor.constraint(equalToConstant: view.frame.width * 0.9)
+        nextButtonWidthConstraint?.isActive = true
+    }
+}
+
+
+#Preview {
+    let vc = WithdrawalDetailViewController()
+    
+    return vc
+}

--- a/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalDetailViewController.swift
+++ b/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalDetailViewController.swift
@@ -62,8 +62,9 @@ class WithdrawalDetailViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureUI()
         
+        view.backgroundColor = .systemBackground
+        configureUI()
         textView.delegate = self
     }
     
@@ -115,14 +116,6 @@ class WithdrawalDetailViewController: UIViewController {
         ])
     }
     
-    private func configureCountLabel() {
-        view.addSubview(remainCountLabel)
-        
-        NSLayoutConstraint.activate([
-        
-        ])
-    }
-    
     private func configureNextButton() {
         view.addSubview(nextButton)
         
@@ -135,10 +128,6 @@ class WithdrawalDetailViewController: UIViewController {
             nextButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
         ])
     }
-    
-    private func updateCountLabel(characterCount: Int) {
-            remainCountLabel.text = "\(characterCount)/3000"
-        }
 }
 
 extension WithdrawalDetailViewController: UITextViewDelegate {
@@ -204,9 +193,9 @@ extension WithdrawalDetailViewController {
     }
 }
 
-
-#Preview {
-    let vc = WithdrawalDetailViewController()
-    
-    return vc
-}
+//
+//#Preview {
+//    let vc = WithdrawalDetailViewController()
+//    
+//    return vc
+//}

--- a/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalDetailViewController.swift
+++ b/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalDetailViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import Combine
 
 class WithdrawalDetailViewController: UIViewController {
     private let placeHolderText = "후기 작성 시 유의사항 한 번 확인하기!\n후기를 보는 사용자와 사업자에게 상처가 되는\n욕설, 비방, 명예훼손성 표현은 사용하지 말아주세요"
@@ -59,13 +60,50 @@ class WithdrawalDetailViewController: UIViewController {
     
     private let nextButton = NextButton(title: "확인", backgroundColor: .roomeMain, tintColor: .white)
     private var nextButtonWidthConstraint: NSLayoutConstraint?
+    
+    private var viewModel: WithdrawalViewModel
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(viewModel: WithdrawalViewModel) {
+        self.viewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
         
         view.backgroundColor = .systemBackground
-        configureUI()
         textView.delegate = self
+        configureUI()
+        bind()
+    }
+    
+    private func bind() {
+        backButton.publisher(for: .touchUpInside)
+            .sink { [weak self] in
+                self?.dismiss(animated: false)
+            }
+            .store(in: &cancellables)
+        
+        jumpButton.publisher(for: .touchUpInside)
+            .sink { [weak self] in
+                let next = DIContainer.shared.resolve(WithdrawalAgreeViewController.self)
+                next.modalPresentationStyle = .fullScreen
+                self?.present(next, animated: false)
+            }
+            .store(in: &cancellables)
+        
+        nextButton.publisher(for: .touchUpInside)
+            .sink { [weak self] in
+                let next = DIContainer.shared.resolve(WithdrawalAgreeViewController.self)
+                next.modalPresentationStyle = .fullScreen
+                self?.present(next, animated: false)
+            }
+            .store(in: &cancellables)
     }
     
     private func configureUI() {

--- a/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalViewController.swift
+++ b/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalViewController.swift
@@ -65,7 +65,7 @@ class WithdrawalViewController: UIViewController, UICollectionViewDelegate {
         view.addSubview(titleLabel)
         
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: backButton.bottomAnchor, constant: 12),
+            titleLabel.topAnchor.constraint(equalTo: backButton.bottomAnchor, constant: 24),
             titleLabel.leadingAnchor.constraint(equalTo: backButton.leadingAnchor),
             titleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12)
         ])

--- a/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalViewController.swift
+++ b/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalViewController.swift
@@ -1,0 +1,149 @@
+//
+//  WithdrawalViewController.swift
+//  roome
+//
+//  Created by minsong kim on 7/11/24.
+//
+
+import UIKit
+
+class WithdrawalViewController: UIViewController, UICollectionViewDelegate {
+    private let backButton = BackButton()
+    
+    private let jumpButton: UIButton = {
+        let button = UIButton()
+        button.setTitle("넘어가기", for: .normal)
+        button.titleLabel?.font = .boldTitle3
+        button.setTitleColor(.label, for: .normal)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        
+        return button
+    }()
+    
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "탈퇴하는 이유가 무엇인가요?"
+        label.sizeToFit()
+        label.textAlignment = .left
+        label.font = .boldTitle2
+        label.translatesAutoresizingMaskIntoConstraints = false
+        
+        return label
+    }()
+    
+    private var collectionView: UICollectionView!
+    private var dataSource: UICollectionViewDiffableDataSource<Int, WithdrawalItem>?
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .systemBackground
+
+        configureNavigationBar()
+        configureTitle()
+        registerCollectionView()
+        configureCollectionView()
+        setDataSource()
+        setSnapShot()
+        collectionView.delegate = self
+    }
+    
+    private func configureNavigationBar() {
+        view.addSubview(backButton)
+        view.addSubview(jumpButton)
+        
+        NSLayoutConstraint.activate([
+            backButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            backButton.widthAnchor.constraint(equalToConstant: 24),
+            backButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 12),
+            
+            jumpButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
+            jumpButton.centerYAnchor.constraint(equalTo: backButton.centerYAnchor)
+        ])
+    }
+    
+    private func configureTitle() {
+        view.addSubview(titleLabel)
+        
+        NSLayoutConstraint.activate([
+            titleLabel.topAnchor.constraint(equalTo: backButton.bottomAnchor, constant: 12),
+            titleLabel.leadingAnchor.constraint(equalTo: backButton.leadingAnchor),
+            titleLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -12)
+        ])
+    }
+    
+    private func configureCollectionView() {
+        view.addSubview(collectionView)
+        collectionView.backgroundColor = .systemBackground
+        collectionView?.translatesAutoresizingMaskIntoConstraints = false
+        
+        NSLayoutConstraint.activate([
+            collectionView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+            collectionView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            collectionView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+        ])
+    }
+    
+    private func registerCollectionView() {
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: createLayout())
+        collectionView.contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        collectionView.register(WithdrawalCollectionViewCell.self, forCellWithReuseIdentifier: WithdrawalCollectionViewCell.id)
+    }
+    
+    private func createLayout() -> UICollectionViewLayout {
+        UICollectionViewCompositionalLayout(sectionProvider: { [weak self] sectionIndex, _ in
+            return self?.createSection()
+        })
+    }
+    
+    private func createSection() -> NSCollectionLayoutSection {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(60))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1.0), heightDimension: .estimated(100))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        
+        let section = NSCollectionLayoutSection(group: group)
+        section.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 0, bottom: 16, trailing: 0)
+        
+        return section
+    }
+    
+    private func setDataSource() {
+        dataSource = UICollectionViewDiffableDataSource<Int, WithdrawalItem>(collectionView: collectionView, cellProvider: { collectionView, indexPath, itemIdentifier in
+            guard let cell = collectionView.dequeueReusableCell(
+                withReuseIdentifier: WithdrawalCollectionViewCell.id,
+                for: indexPath) as? WithdrawalCollectionViewCell else {
+                return UICollectionViewCell()
+            }
+    
+            cell.configureCell(title: WithdrawalItem.allCases[indexPath.row].rawValue)
+            
+            return cell
+        })
+    }
+    
+    private func setSnapShot() {
+        var snapshot = NSDiffableDataSourceSnapshot<Int, WithdrawalItem>()
+        let withdrawalItems: [WithdrawalItem] = [.notEnoughFunction, .rarelyUseService, .tooManyError, .worriedPersonalInformation, .wantReSignIn, .etc]
+        snapshot.appendSections([0])
+        snapshot.appendItems(withdrawalItems, toSection: 0)
+        
+        dataSource?.apply(snapshot)
+    }
+}
+
+enum WithdrawalItem: String, CaseIterable {
+    case notEnoughFunction = "원하는 기능이 없어요"
+    case rarelyUseService = "서비스를 자주 사용하지 않아요"
+    case tooManyError = "서비스 오류가 많아요"
+    case worriedPersonalInformation = "개인 정보 및 보안이 걱정돼요"
+    case wantReSignIn = "탈퇴 후 재가입하고 싶어요"
+    case etc = "기타"
+}
+
+//#Preview {
+//    let vc = WithdrawalViewController()
+//    
+//    return vc
+//}

--- a/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalViewModel.swift
+++ b/roome/roome/Main/Presentation/Setting/Withdrawal/WithdrawalViewModel.swift
@@ -1,0 +1,118 @@
+//
+//  WithdrawalViewModel.swift
+//  roome
+//
+//  Created by minsong kim on 7/12/24.
+//
+
+import Foundation
+import Combine
+import AuthenticationServices
+import KakaoSDKUser
+
+class WithdrawalViewModel: NSObject {
+    struct Input {
+        let tappedWithdrawal = PassthroughSubject<Void, Never>()
+        let tappedWithdrawalReasonCell = PassthroughSubject<WithdrawalItem, Never>()
+    }
+    
+    struct Output {
+        let handleWithdrawal = PassthroughSubject<Result<Void, Error>, Never>()
+        let handleReason = PassthroughSubject<Result<Void, Error>, Never>()
+    }
+    
+    let input: Input
+    let output: Output
+    
+    private var cancellables = Set<AnyCancellable>()
+    
+    init(loginUseCase: LoginUseCase) {
+        self.loginUseCase = loginUseCase
+        self.input = Input()
+        self.output = Output()
+        super.init()
+        settingBind()
+    }
+    
+    let loginUseCase: LoginUseCase?
+    
+    private func settingBind() {
+        input.tappedWithdrawal
+            .sink { [weak self] _ in
+                if KeyChain.read(key: .isAppleLogin) == "true" {
+                    self?.handleAppleSignOut()
+                } else {
+                    self?.handleKakaoSignOut()
+                }
+            }
+            .store(in: &cancellables)
+        
+        input.tappedWithdrawalReasonCell
+            .sink { [weak self] reason in
+                //API로 이유 전송
+                self?.output.handleReason.send(.success({}()))
+            }
+            .store(in: &cancellables)
+    }
+    
+    private func handleAppleSignOut() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.performRequests()
+    }
+    
+    private func handleKakaoSignOut() {
+        UserApi.shared.unlink { [self] error in
+            if let error {
+                print(error)
+            } else {
+                print("unlink() success")
+                
+                let bodyJSON: [String: Any?] = ["provider": LoginProvider.kakao.name,
+                                               "code": nil]
+                //탈퇴 시켜줘
+                Task {
+                    do {
+                        try await self.loginUseCase?.signOutWithAPI(body: bodyJSON)
+                        KeyChain.delete(key: .accessToken)
+                        KeyChain.delete(key: .refreshToken)
+                        KeyChain.delete(key: .hasToken)
+                        output.handleWithdrawal.send(.success({}()))
+                    } catch(let error) {
+                        output.handleWithdrawal.send(.failure(error))
+                    }
+                }
+            }
+        }
+    }
+}
+
+extension WithdrawalViewModel: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        guard let credential = authorization.credential as? ASAuthorizationAppleIDCredential else {
+            return
+        }
+        //TODO: - 도메인에 넘겨줄 body Type 따로 정의해서 분리하기
+        let bodyJSON: [String: Any] = ["provider": LoginProvider.apple.name,
+                                        "code": String(data: credential.authorizationCode ?? Data(), encoding: .utf8) ?? ""]
+        
+        Task {
+            do {
+                try await loginUseCase?.signOutWithAPI(body: bodyJSON)
+                //키체인에 유저 정보 삭제
+                KeyChain.delete(key: .accessToken)
+                KeyChain.delete(key: .refreshToken)
+                KeyChain.delete(key: .hasToken)
+                KeyChain.delete(key: .isAppleLogin)
+                KeyChain.delete(key: .appleUserID)
+                output.handleWithdrawal.send(.success({}()))
+            } catch(let error) {
+                output.handleWithdrawal.send(.failure(error))
+            }
+        }
+    }
+}

--- a/roome/roome/ProfileSelect/Data/Repository/ProfileSelectRepository.swift
+++ b/roome/roome/ProfileSelect/Data/Repository/ProfileSelectRepository.swift
@@ -116,7 +116,7 @@ class ProfileSelectRepository: ProfileSelectRepositoryType {
     }
     
     private func checkURL(_ state: StateDTO) throws -> URL {
-        var path: APIConstants.Profile = {
+        let path: APIConstants.Profile = {
             switch state {
             case .roomCountRanges:
                     .roomCount

--- a/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
+++ b/roome/roome/ProfileSelect/Presentation/View/MBTIViewController.swift
@@ -16,21 +16,7 @@ class MBTIViewController: UIViewController {
     private lazy var flowLayout = self.createFlowLayout()
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.flowLayout)
     
-    private let willNotAddButton: UIButton = {
-        var configuration = UIButton.Configuration.plain()
-        configuration.baseForegroundColor = .label
-        configuration.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.gray).resize(newWidth: 24)
-        configuration.imagePadding = 8
-        configuration.contentInsets = NSDirectionalEdgeInsets(top: 15, leading: 24, bottom: 10, trailing: 20)
-        configuration.title = "프로필에 추가하지 않을래요"
-        
-        let button = UIButton(configuration: configuration)
-        button.titleLabel?.font = .regularBody2
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.contentHorizontalAlignment = .leading
-        
-        return button
-    }()
+    private let willNotAddButton = AgreeButton(title: "프로필에 추가하지 않을래요")
     
     var viewModel: MBTIViewModel
     var cancellables = Set<AnyCancellable>()
@@ -109,12 +95,11 @@ class MBTIViewController: UIViewController {
         
         viewModel.output.handleNotAddButton
             .sink { [weak self] willNotAdd in
+                self?.willNotAddButton.isSelected = willNotAdd
                 if willNotAdd {
-                    self?.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.roomeMain).resize(newWidth: 24)
                     _ = self?.collectionView.visibleCells.map { $0.isSelected = false }
                     self?.collectionView.reloadData()
                 } else {
-                    self?.willNotAddButton.configuration?.image = UIImage(systemName: "checkmark.circle.fill")?.changeImageColor(.gray).resize(newWidth: 24)
                     _ = self?.collectionView.visibleCells
                         .compactMap { $0 as? ButtonCell }
                         .map { $0.isChecked = false }
@@ -169,9 +154,9 @@ class MBTIViewController: UIViewController {
         view.addSubview(willNotAddButton)
         
         NSLayoutConstraint.activate([
-            willNotAddButton.topAnchor.constraint(equalTo: collectionView.bottomAnchor),
-            willNotAddButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            willNotAddButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+            willNotAddButton.topAnchor.constraint(equalTo: collectionView.bottomAnchor, constant: 12),
+            willNotAddButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: 24),
+            willNotAddButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -24),
         ])
     }
     

--- a/roome/roome/SignUp/Presentation/View/NicknameViewController.swift
+++ b/roome/roome/SignUp/Presentation/View/NicknameViewController.swift
@@ -66,7 +66,6 @@ class NicknameViewController: UIViewController {
     }()
     
     private let nextButton = NextButton()
-    
     private var nextButtonWidthConstraint: NSLayoutConstraint?
     private let backButton = BackButton()
     

--- a/roome/roome/SignUp/Presentation/View/NicknameViewController.swift
+++ b/roome/roome/SignUp/Presentation/View/NicknameViewController.swift
@@ -188,7 +188,6 @@ class NicknameViewController: UIViewController {
             welcomeLabel.leadingAnchor.constraint(equalTo: backButton.leadingAnchor, constant: 12),
             welcomeLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -10)
         ])
-        
     }
     
     private func configureFields() {

--- a/roome/roome/SignUp/Presentation/View/TermsAgreeViewController.swift
+++ b/roome/roome/SignUp/Presentation/View/TermsAgreeViewController.swift
@@ -25,7 +25,6 @@ class TermsAgreeViewController: UIViewController {
     private let titleLabel: PaddingLabel = {
         let label = PaddingLabel()
         label.text = "서비스 이용약관"
-        label.numberOfLines = 2
         label.sizeToFit()
         label.textAlignment = .left
         label.textColor = .label
@@ -138,7 +137,7 @@ class TermsAgreeViewController: UIViewController {
                 switch completion {
                 case .finished:
                     print("finished")
-                case .failure(let error):
+                case .failure(_):
                     self.window?.addSubview(self.errorPopUp)
                 }
             } receiveValue: { [weak self] in


### PR DESCRIPTION
## 📚 작업 설명
- 회원 탈퇴 플로우 구현
- 탈퇴 사유 선택
- 기타 입력 
- 정보 삭제 안내 동의

## 🔥 트러블 슈팅
### 1️⃣. PopUpView.removeFromSuperView()가 연결이 안 되었을 때
| 탈퇴 완료 |
|:--------:|
|<img src="https://github.com/user-attachments/assets/a3ca1231-078a-4bfd-86dc-ddb3c3860bfe"  alt="diary_scroll" width="300">|

위와 같은 탈퇴 후 완료를 안내해주는 PopUpView의 확인 버튼을 눌럭도 removeFromSuperView() 가 동작하지 않는 문제가 있었다. 
해당 PopUpView를 생성하여 띄우는 페이지는 탈퇴 동의 페이지에서 탈퇴에 성공한 경우 띄우는데, 이때 확인 버튼을 눌렀을 때 binding되어 동작하는 로직을 구현한 곳 역시 탈퇴 동의 페이지이다. 때문에 연결이 되지 않아 문제가 되었던 것 같다. 

-> 결국 PopUpView에서 color 버튼을 누르는 경우 스스로를 removeFromSuperview가 되는 함수를 별도로 구현하여 해당 함수를 호출 가능하도록 변경하였다. 다만 이렇게되니 PopUpView의 역할이 애매한 것 같아서 고민중이다. 
